### PR TITLE
Added setter for contentsScale

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,11 @@ use std::any::Any;
 use std::fmt;
 use std::mem;
 
+#[cfg(target_pointer_width = "64")]
+pub type CGFloat = libc::c_double;
+#[cfg(not(target_pointer_width = "64"))]
+pub type CGFloat = libc::c_float;
+
 #[allow(non_camel_case_types)]
 #[repr(C)]
 pub struct id<T=()>(pub *mut Object, pub PhantomData<T>);
@@ -286,6 +291,12 @@ impl CAMetalLayer {
                 true => None,
                 false => Some(drawable)
             }
+        }
+    }
+
+    pub fn set_contents_scale(&self, scale: CGFloat) {
+        unsafe {
+            msg_send![self.0, contentsScale:scale];
         }
     }
 }


### PR DESCRIPTION
I need this setter to be able to set right scaling factor for the layer.

There's one but: I also added the definition for the `CGFloat` type. However, this type is already defined in `core-graphics` crate. It's just a one type, but if there is more redundancy, it should be considered to depend on `core-graphics`, since the types from there are used quite throughly.