### PR TITLE
Improve memory safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ cocoa = "0.9.0"
 bitflags = "0.9"
 libc = "0.2"
 objc-foundation = "0.1"
+objc_id = "0.1"
 block = "0.1.5"
 foreign-types = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bitflags = "0.9"
 libc = "0.2"
 objc-foundation = "0.1"
 block = "0.1.5"
+foreign-types = "0.3"
 
 [dependencies.objc]
 version = "0.2.1"

--- a/examples/caps/main.rs
+++ b/examples/caps/main.rs
@@ -10,7 +10,7 @@ extern crate metal_rs as metal;
 use metal::*;
 
 fn main() {
-    let device = create_system_default_device();
+    let device = Device::system_default();
 
     println!("Vendor: {:?}", device.vendor());
     println!("Family: {:?}", device.family_name());

--- a/examples/indirect/main.rs
+++ b/examples/indirect/main.rs
@@ -6,29 +6,42 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate metal_rs as metal;
+extern crate cocoa;
+#[macro_use] extern crate objc;
+extern crate objc_id;
+extern crate objc_foundation;
 
 use metal::*;
 
-fn main() {
-    let device = create_system_default_device();
+use cocoa::foundation::NSAutoreleasePool;
+use objc_foundation::{NSArray, INSArray};
+use objc_id::Id;
 
-    let desc1 = MTLArgumentDescriptor::new();
+fn main() {
+    let mut pool = unsafe { NSAutoreleasePool::new(cocoa::base::nil) };
+
+    let device = Device::system_default();
+
+    let desc1 = ArgumentDescriptor::new();
     desc1.set_index(1);
     desc1.set_data_type(MTLDataType::Sampler);
-    let desc2 = MTLArgumentDescriptor::new();
+    let desc2 = ArgumentDescriptor::new();
     desc2.set_data_type(MTLDataType::Texture);
 
-    let arguments = NSArray::array_with_objects(&[desc1, desc2]);
-    let encoder = device.new_argument_encoder(arguments);
+    let encoder = device.new_argument_encoder(&Array::from_slice(&[desc1, desc2]));
     println!("{:?}", encoder);
 
     let buffer = device.new_buffer(encoder.encoded_length(), MTLResourceOptions::empty());
-    encoder.set_argument_buffer(buffer, 0);
+    encoder.set_argument_buffer(&buffer, 0);
 
     let sampler = {
-        let descriptor = MTLSamplerDescriptor::new();
-        device.new_sampler(descriptor)
+        let descriptor = SamplerDescriptor::new();
+        device.new_sampler(&descriptor)
     };
-    encoder.set_sampler_states(&[sampler], 0);
+    encoder.set_sampler_states(&[&sampler], 0);
     println!("{:?}", sampler);
+
+    unsafe {
+        msg_send![pool, release];
+    }
 }

--- a/examples/library/main.rs
+++ b/examples/library/main.rs
@@ -12,8 +12,8 @@ use metal::*;
 const PROGRAM: &'static str = "";
 
 fn main() {
-    let device = create_system_default_device();
+    let device = Device::system_default();
 
-    let options = MTLCompileOptions::new();
-    let library = device.new_library_with_source(PROGRAM, options);
+    let options = CompileOptions::new();
+    let library = device.new_library_with_source(PROGRAM, &options);
 }

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use ::{Array, MTLTextureType};
+
 use cocoa::foundation::NSUInteger;
 use objc::runtime::{Class, YES, NO};
-use objc_foundation::{NSString, INSString, NSArray};
-
-use texture::MTLTextureType;
+use objc_foundation::{NSString, INSString};
 
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -119,137 +119,140 @@ foreign_obj_type! {
     pub struct StructMemberRef;
 }
 
-/*
-impl<'a> MTLStructMember {
-    pub fn name(&'a self) -> &'a str {
+impl StructMemberRef {
+    pub fn name(&self) -> &str {
         unsafe {
-            let name: &'a NSString = msg_send![self.0, name];
+            let name: &NSString = msg_send![self, name];
             name.as_str()
         }
     }
 
-    pub fn offset(&self) -> u64 {
+    pub fn offset(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, offset]
+            msg_send![self, offset]
         }
     }
 
     pub fn data_type(&self) -> MTLDataType {
         unsafe {
-            msg_send![self.0, dataType]
+            msg_send![self, dataType]
         }
     }
 
     pub fn struct_type(&self) -> MTLStructType {
         unsafe {
-            msg_send![self.0, structType]
+            msg_send![self, structType]
         }
     }
 
     pub fn array_type(&self) -> MTLArrayType {
         unsafe {
-            msg_send![self.0, arrayType]
-        }
-    }
-}*/
-/*
-pub enum MTLStructTypePrototype {}
-pub type MTLStructType = id<(MTLStructTypePrototype, (NSObjectPrototype, ()))>;
-
-impl<'a> MTLStructType {
-    pub fn members(&self) -> NSArray<MTLStructMember> {
-        unsafe {
-            msg_send![self.0, members]
-        }
-    }
-
-    pub fn member_from_name(&self, name: &str) -> MTLStructMember {
-        let nsname = NSString::from_str(name);
-
-        unsafe {
-            msg_send![self.0, memberByName:nsname]
+            msg_send![self, arrayType]
         }
     }
 }
 
-impl NSObjectProtocol for MTLStructType {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLStructType").unwrap()
-    }
-}*/
-/*
-pub enum MTLArrayTypePrototype {}
-pub type MTLArrayType = id<(MTLArrayTypePrototype, (NSObjectPrototype, ()))>;
+pub enum MTLStructType {}
 
-impl MTLArrayType {
-    pub fn array_length(&self) -> u64 {
+foreign_obj_type! {
+    type CType = MTLStructType;
+    pub struct StructType;
+    pub struct StructTypeRef;
+}
+
+impl StructTypeRef {
+    pub fn members(&self) -> &Array<StructMember> {
         unsafe {
-            msg_send![self.0, arrayLength]
+            msg_send![self, members]
         }
     }
 
-    pub fn stride(&self) -> u64 {
+    pub fn member_from_name(&self, name: &str) -> Option<&StructMemberRef> {
+        let nsname = NSString::from_str(name);
+
         unsafe {
-            msg_send![self.0, stride]
+            msg_send![self, memberByName:nsname]
+        }
+    }
+}
+
+pub enum MTLArrayType {}
+
+foreign_obj_type! {
+    type CType = MTLArrayType;
+    pub struct ArrayType;
+    pub struct ArrayTypeRef;
+}
+
+impl ArrayTypeRef {
+    pub fn array_length(&self) -> NSUInteger {
+        unsafe {
+            msg_send![self, arrayLength]
+        }
+    }
+
+    pub fn stride(&self) -> NSUInteger {
+        unsafe {
+            msg_send![self, stride]
         }
     }
 
     pub fn element_type(&self) -> MTLDataType {
         unsafe {
-            msg_send![self.0, elementType]
+            msg_send![self, elementType]
         }
     }
 
     pub fn element_struct_type(&self) -> MTLStructType {
         unsafe {
-            msg_send![self.0, elementStructType]
+            msg_send![self, elementStructType]
         }
     }
 
     pub fn element_array_type(&self) -> MTLArrayType {
         unsafe {
-            msg_send![self.0, elementArrayType]
+            msg_send![self, elementArrayType]
         }
     }
 }
 
-impl NSObjectProtocol for MTLArrayType {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLArrayType").unwrap()
-    }
-}*/
-/*
-pub enum MTLArgumentPrototype {}
-pub type MTLArgument = id<(MTLArgumentPrototype, (NSObjectPrototype, ()))>;
-impl<'a> MTLArgument {
-    pub fn name(&'a self) -> &'a str {
+pub enum MTLArgument {}
+
+foreign_obj_type! {
+    type CType = MTLArgument;
+    pub struct Argument;
+    pub struct ArgumentRef;
+}
+
+impl ArgumentRef {
+    pub fn name(&self) -> &str {
         unsafe {
-            let name: &'a NSString = msg_send![self.0, name];
+            let name: &NSString = msg_send![self, name];
             name.as_str()
         }
     }
 
     pub fn type_(&self) -> MTLArgumentType {
         unsafe {
-            msg_send![self.0, type]
+            msg_send![self, type]
         }
     }
 
     pub fn access(&self) -> MTLArgumentAccess {
         unsafe {
-            msg_send![self.0, access]
+            msg_send![self, access]
         }
     }
 
-    pub fn index(&self) -> u64 {
+    pub fn index(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, index]
+            msg_send![self, index]
         }
     }
 
     pub fn is_active(&self) -> bool {
         unsafe {
-            match msg_send![self.0, isActive] {
+            match msg_send![self, isActive] {
                 YES => true,
                 NO => false,
                 _ => unreachable!()
@@ -257,104 +260,100 @@ impl<'a> MTLArgument {
         }
     }
 
-    pub fn buffer_alignment(&self) -> u64 {
+    pub fn buffer_alignment(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, bufferAlignment]
+            msg_send![self, bufferAlignment]
         }
     }
 
-    pub fn buffer_data_size(&self) -> u64 {
+    pub fn buffer_data_size(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, bufferDataSize]
+            msg_send![self, bufferDataSize]
         }
     }
 
     pub fn buffer_data_type(&self) -> MTLDataType {
         unsafe {
-            msg_send![self.0, bufferDataType]
+            msg_send![self, bufferDataType]
         }
     }
 
-    pub fn buffer_struct_type(&self) -> MTLStructType {
+    pub fn buffer_struct_type(&self) -> &StructTypeRef {
         unsafe {
-            msg_send![self.0, bufferStructType]
+            msg_send![self, bufferStructType]
         }
     }
 
-    pub fn threadgroup_memory_alignment(&self) -> u64 {
+    pub fn threadgroup_memory_alignment(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, threadgroupMemoryAlignment]
+            msg_send![self, threadgroupMemoryAlignment]
         }
     }
 
-    pub fn threadgroup_memory_data_size(&self) -> u64 {
+    pub fn threadgroup_memory_data_size(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, threadgroupMemoryDataSize]
+            msg_send![self, threadgroupMemoryDataSize]
         }
     }
 
     pub fn texture_type(&self) -> MTLTextureType {
         unsafe {
-            msg_send![self.0, textureType]
+            msg_send![self, textureType]
         }
     }
 
     pub fn texture_data_type(&self) -> MTLDataType {
         unsafe {
-            msg_send![self.0, textureDataType]
+            msg_send![self, textureDataType]
         }
     }
 }
 
-impl NSObjectProtocol for MTLArgument {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLArgument").unwrap()
-    }
-}*/
+pub enum MTLArgumentDescriptor {}
 
-/*
-pub enum MTLArgumentDescriptorPrototype {}
-pub type MTLArgumentDescriptor = id<(MTLArgumentDescriptorPrototype, (NSObjectPrototype, ()))>;
-impl NSObjectProtocol for MTLArgumentDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLArgumentDescriptor").unwrap()
-    }
+foreign_obj_type! {
+    type CType = MTLArgumentDescriptor;
+    pub struct ArgumentDescriptor;
+    pub struct ArgumentDescriptorRef;
 }
 
-impl MTLArgumentDescriptor {
-    pub fn new() -> Self {
+impl ArgumentDescriptor {
+    pub fn new<'a>() -> &'a ArgumentDescriptorRef {
         unsafe {
-            msg_send![Self::class(), argumentDescriptor]
+            let class = Class::get("MTLArgumentDescriptor").unwrap();
+            msg_send![class, argumentDescriptor]
         }
     }
+}
 
+impl ArgumentDescriptorRef {
     pub fn set_data_type(&self, ty: MTLDataType) {
         unsafe {
-            msg_send![self.0, setDataType:ty]
+            msg_send![self, setDataType:ty]
         }
     }
 
     pub fn set_index(&self, index: NSUInteger) {
         unsafe {
-            msg_send![self.0, setIndex:index]
+            msg_send![self, setIndex:index]
         }
     }
 
     pub fn set_access(&self, access: MTLArgumentAccess) {
         unsafe {
-            msg_send![self.0, setAccess:access]
+            msg_send![self, setAccess:access]
         }
     }
 
     pub fn set_array_length(&self, length: NSUInteger) {
         unsafe {
-            msg_send![self.0, setArrayLength:length]
+            msg_send![self, setArrayLength:length]
         }
     }
 
     pub fn set_texture_type(&self, ty: MTLTextureType) {
         unsafe {
-            msg_send![self.0, setTextureType:ty]
+            msg_send![self, setTextureType:ty]
         }
     }
-}*/
+}

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -9,8 +9,6 @@ use cocoa::foundation::NSUInteger;
 use objc::runtime::{Class, YES, NO};
 use objc_foundation::{NSString, INSString, NSArray};
 
-use super::{id, NSObjectPrototype, NSObjectProtocol};
-
 use texture::MTLTextureType;
 
 #[repr(u64)]
@@ -113,10 +111,15 @@ pub enum MTLArgumentAccess {
     WriteOnly  = 2,
 }
 
+pub enum MTLStructMember {}
 
-pub enum MTLStructMemberPrototype {}
-pub type MTLStructMember = id<(MTLStructMemberPrototype, (NSObjectPrototype, ()))>;
+foreign_obj_type! {
+    type CType = MTLStructMember;
+    pub struct StructMember;
+    pub struct StructMemberRef;
+}
 
+/*
 impl<'a> MTLStructMember {
     pub fn name(&'a self) -> &'a str {
         unsafe {
@@ -148,8 +151,8 @@ impl<'a> MTLStructMember {
             msg_send![self.0, arrayType]
         }
     }
-}
-
+}*/
+/*
 pub enum MTLStructTypePrototype {}
 pub type MTLStructType = id<(MTLStructTypePrototype, (NSObjectPrototype, ()))>;
 
@@ -173,8 +176,8 @@ impl NSObjectProtocol for MTLStructType {
     unsafe fn class() -> &'static Class {
         Class::get("MTLStructType").unwrap()
     }
-}
-
+}*/
+/*
 pub enum MTLArrayTypePrototype {}
 pub type MTLArrayType = id<(MTLArrayTypePrototype, (NSObjectPrototype, ()))>;
 
@@ -214,11 +217,10 @@ impl NSObjectProtocol for MTLArrayType {
     unsafe fn class() -> &'static Class {
         Class::get("MTLArrayType").unwrap()
     }
-}
-
+}*/
+/*
 pub enum MTLArgumentPrototype {}
 pub type MTLArgument = id<(MTLArgumentPrototype, (NSObjectPrototype, ()))>;
-
 impl<'a> MTLArgument {
     pub fn name(&'a self) -> &'a str {
         unsafe {
@@ -308,12 +310,11 @@ impl NSObjectProtocol for MTLArgument {
     unsafe fn class() -> &'static Class {
         Class::get("MTLArgument").unwrap()
     }
-}
+}*/
 
-
+/*
 pub enum MTLArgumentDescriptorPrototype {}
 pub type MTLArgumentDescriptor = id<(MTLArgumentDescriptorPrototype, (NSObjectPrototype, ()))>;
-
 impl NSObjectProtocol for MTLArgumentDescriptor {
     unsafe fn class() -> &'static Class {
         Class::get("MTLArgumentDescriptor").unwrap()
@@ -356,4 +357,4 @@ impl MTLArgumentDescriptor {
             msg_send![self.0, setTextureType:ty]
         }
     }
-}
+}*/

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -8,16 +8,19 @@
 use cocoa::foundation::NSRange;
 use objc::runtime::Class;
 
-use super::{id, NSObjectPrototype, NSObjectProtocol};
-
 use libc;
 
-use resource::{MTLResourcePrototype};
 use texture::{MTLTexture, MTLTextureDescriptor};
 
-pub enum MTLBufferPrototype {}
-pub type MTLBuffer = id<(MTLBufferPrototype, (MTLResourcePrototype, (NSObjectPrototype, ())))>;
+pub enum MTLBuffer {}
 
+foreign_obj_type! {
+    type CType = MTLBuffer;
+    pub struct Buffer;
+    pub struct BufferRef;
+}
+
+/*
 impl MTLBuffer {
     pub fn length(&self) -> u64 {
         unsafe {
@@ -50,5 +53,5 @@ impl NSObjectProtocol for MTLBuffer {
     unsafe fn class() -> &'static Class {
         Class::get("MTLBuffer").unwrap()
     }
-}
+}*/
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -5,12 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use super::*;
+
 use cocoa::foundation::NSRange;
-use objc::runtime::Class;
-
-use libc;
-
-use texture::{MTLTexture, MTLTextureDescriptor};
 
 pub enum MTLBuffer {}
 
@@ -18,40 +15,34 @@ foreign_obj_type! {
     type CType = MTLBuffer;
     pub struct Buffer;
     pub struct BufferRef;
+    type ParentType = ResourceRef;
 }
 
-/*
-impl MTLBuffer {
+
+impl BufferRef {
     pub fn length(&self) -> u64 {
         unsafe {
-            msg_send![self.0, length]
+            msg_send![self, length]
         }
     }
 
     pub fn contents(&self) -> *mut libc::c_void {
         unsafe {
-            msg_send![self.0, contents]
+            msg_send![self, contents]
         }
     }
 
     pub fn did_modify_range(&self, range: NSRange) {
         unsafe {
-            msg_send![self.0, didModifyRange:range]
+            msg_send![self, didModifyRange:range]
         }
     }
 
-    pub fn new_texture_from_contents(&self, descriptor: MTLTextureDescriptor, offset: u64, stride: u64) -> MTLTexture {
+    pub fn new_texture_from_contents(&self, descriptor: &TextureDescriptorRef, offset: u64, stride: u64) -> Texture {
         unsafe {
-            msg_send![self.0, newTextureWithDescriptor:descriptor.0
-                                                offset:offset
-                                           bytesPerRow:stride]
+            msg_send![self, newTextureWithDescriptor:descriptor
+                                              offset:offset
+                                         bytesPerRow:stride]
         }
     }
 }
-
-impl NSObjectProtocol for MTLBuffer {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLBuffer").unwrap()
-    }
-}*/
-

--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -5,11 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use objc::runtime::Class;
+use super::*;
+
 use objc_foundation::{NSString, INSString};
 use block::Block;
-
-use encoder::{MTLParallelRenderCommandEncoder, MTLRenderCommandEncoder, MTLBlitCommandEncoder};
 
 #[repr(u32)]
 #[allow(non_camel_case_types)]
@@ -45,11 +44,10 @@ foreign_obj_type! {
     pub struct CommandBufferRef;
 }
 
-/*
-impl<'a> MTLCommandBuffer {
-    pub fn label(&'a self) -> &'a str {
+impl CommandBufferRef {
+    pub fn label(&self) -> &str {
         unsafe {
-            let label: &'a NSString = msg_send![self.0, label];
+            let label: &NSString = msg_send![self, label];
             label.as_str()
         }
     }
@@ -57,74 +55,67 @@ impl<'a> MTLCommandBuffer {
     pub fn set_label(&self, label: &str) {
         unsafe {
             let nslabel = NSString::from_str(label);
-            msg_send![self.0, setLabel:nslabel]
+            msg_send![self, setLabel:nslabel];
         }
     }
 
     pub fn enqueue(&self) {
         unsafe {
-            msg_send![self.0, enqueue]
+            msg_send![self, enqueue]
         }
     }
 
     pub fn commit(&self) {
         unsafe {
-            msg_send![self.0, commit]
+            msg_send![self, commit]
         }
     }
 
     pub fn status(&self) -> MTLCommandBufferStatus {
         unsafe {
-            msg_send![self.0, status]
+            msg_send![self, status]
         }
     }
 
-    pub fn present_drawable<T>(&self, drawable: id<T>) {
+    pub fn present_drawable(&self, drawable: &DrawableRef) {
         unsafe {
-            msg_send![self.0, presentDrawable:drawable]
+            msg_send![self, presentDrawable:drawable]
         }
     }
 
     pub fn wait_until_completed(&self) {
         unsafe {
-            msg_send![self.0, waitUntilCompleted]
+            msg_send![self, waitUntilCompleted]
         }
     }
 
     pub fn wait_until_scheduled(&self) {
         unsafe {
-            msg_send![self.0, waitUntilScheduled]
+            msg_send![self, waitUntilScheduled]
         }
     }
 
-    pub fn new_blit_command_encoder(&self) -> MTLBlitCommandEncoder {
+    pub fn new_blit_command_encoder(&self) -> &BlitCommandEncoderRef {
         unsafe {
-            msg_send![self.0, blitCommandEncoder]
+            msg_send![self, blitCommandEncoder]
         }
     }
 
-    /*pub fn new_compute_command_encoder(&self) -> id {
+    pub fn new_compute_command_encoder(&self) -> &ComputeCommandEncoderRef {
         unsafe {
-            msg_send![self.0, blitCommandEncoder]
-        }
-    }*/
-
-    pub fn new_render_command_encoder(&self, descriptor: MTLRenderPassDescriptor) -> MTLRenderCommandEncoder {
-        unsafe {
-            msg_send![self.0, renderCommandEncoderWithDescriptor:descriptor.0]
+            msg_send![self, blitCommandEncoder]
         }
     }
 
-    pub fn new_parallel_render_command_encoder(&self, descriptor: MTLRenderPassDescriptor) -> MTLParallelRenderCommandEncoder {
+    pub fn new_render_command_encoder(&self, descriptor: &RenderPassDescriptorRef) -> &RenderCommandEncoderRef {
         unsafe {
-            msg_send![self.0, parallelRenderCommandEncoderWithDescriptor:descriptor.0]
+            msg_send![self, renderCommandEncoderWithDescriptor:descriptor]
+        }
+    }
+
+    pub fn new_parallel_render_command_encoder(&self, descriptor: &RenderPassDescriptorRef) -> &ParallelRenderCommandEncoderRef {
+        unsafe {
+            msg_send![self, parallelRenderCommandEncoderWithDescriptor:descriptor]
         }
     }
 }
-
-impl NSObjectProtocol for MTLCommandBuffer {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLCommandBuffer").unwrap()
-    }
-}*/
-

--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -9,9 +9,6 @@ use objc::runtime::Class;
 use objc_foundation::{NSString, INSString};
 use block::Block;
 
-use super::{id, NSObjectPrototype, NSObjectProtocol};
-
-use renderpass::MTLRenderPassDescriptor;
 use encoder::{MTLParallelRenderCommandEncoder, MTLRenderCommandEncoder, MTLBlitCommandEncoder};
 
 #[repr(u32)]
@@ -40,9 +37,15 @@ pub enum MTLCommandBufferError {
 
 type _MTLCommandBufferHandler = Block<(MTLCommandBuffer), ()>;
 
-pub enum MTLCommandBufferPrototype {}
-pub type MTLCommandBuffer = id<(MTLCommandBufferPrototype, (NSObjectPrototype, ()))>;
+pub enum MTLCommandBuffer {}
 
+foreign_obj_type! {
+    type CType = MTLCommandBuffer;
+    pub struct CommandBuffer;
+    pub struct CommandBufferRef;
+}
+
+/*
 impl<'a> MTLCommandBuffer {
     pub fn label(&'a self) -> &'a str {
         unsafe {
@@ -123,5 +126,5 @@ impl NSObjectProtocol for MTLCommandBuffer {
     unsafe fn class() -> &'static Class {
         Class::get("MTLCommandBuffer").unwrap()
     }
-}
+}*/
 

--- a/src/commandqueue.rs
+++ b/src/commandqueue.rs
@@ -8,13 +8,16 @@
 use objc::runtime::Class;
 use objc_foundation::{NSString, INSString};
 
-use super::{id, NSObjectPrototype, NSObjectProtocol};
-
 use commandbuffer::MTLCommandBuffer;
 
-pub enum MTLCommandQueuePrototype {}
-pub type MTLCommandQueue = id<(MTLCommandQueuePrototype, (NSObjectPrototype, ()))>;
+pub enum MTLCommandQueue {}
 
+foreign_obj_type! {
+    type CType = MTLCommandQueue;
+    pub struct CommandQueue;
+    pub struct CommandQueueRef;
+}
+/*
 impl<'a> MTLCommandQueue {
     pub fn label(&'a self) -> &'a str {
         unsafe {
@@ -47,5 +50,5 @@ impl NSObjectProtocol for MTLCommandQueue {
     unsafe fn class() -> &'static Class {
         Class::get("MTLCommandQueue").unwrap()
     }
-}
+}*/
 

--- a/src/commandqueue.rs
+++ b/src/commandqueue.rs
@@ -5,10 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use objc::runtime::Class;
-use objc_foundation::{NSString, INSString};
+use super::*;
 
-use commandbuffer::MTLCommandBuffer;
+use objc_foundation::{NSString, INSString};
 
 pub enum MTLCommandQueue {}
 
@@ -17,11 +16,11 @@ foreign_obj_type! {
     pub struct CommandQueue;
     pub struct CommandQueueRef;
 }
-/*
-impl<'a> MTLCommandQueue {
-    pub fn label(&'a self) -> &'a str {
+
+impl CommandQueueRef {
+    pub fn label(&self) -> &str {
         unsafe {
-            let label: &'a NSString = msg_send![self.0, label];
+            let label: &NSString = msg_send![self, label];
             label.as_str()
         }
     }
@@ -29,26 +28,19 @@ impl<'a> MTLCommandQueue {
     pub fn set_label(&self, label: &str) {
         unsafe {
             let nslabel = NSString::from_str(label);
-            msg_send![self.0, setLabel:nslabel]
+            msg_send![self, setLabel:nslabel]
         }
     }
 
-    pub fn new_command_buffer(&self) -> MTLCommandBuffer {
+    pub fn new_command_buffer(&self) -> &CommandBufferRef {
         unsafe {
-            msg_send![self.0, commandBuffer]
+            msg_send![self, commandBuffer]
         }
     }
 
-    pub fn new_command_buffer_with_unretained_references(&self) -> MTLCommandBuffer {
+    pub fn new_command_buffer_with_unretained_references(&self) -> &CommandBufferRef {
         unsafe {
-            msg_send![self.0, commandBufferWithUnretainedReferences]
+            msg_send![self, commandBufferWithUnretainedReferences]
         }
     }
 }
-
-impl NSObjectProtocol for MTLCommandQueue {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLCommandQueue").unwrap()
-    }
-}*/
-

--- a/src/depthstencil.rs
+++ b/src/depthstencil.rs
@@ -7,8 +7,6 @@
 
 use objc::runtime::{Class, YES, NO};
 
-use super::{id, NSObjectPrototype, NSObjectProtocol};
-
 #[repr(u64)]
 pub enum MTLCompareFunction {
     Never = 0,
@@ -33,9 +31,14 @@ pub enum MTLStencilOperation {
     DecrementWrap = 7,
 }
 
-pub enum MTLStencilDescriptorPrototype {}
-pub type MTLStencilDescriptor = id<(MTLStencilDescriptorPrototype, (NSObjectPrototype, ()))>;
+pub enum MTLStencilDescriptor {}
 
+foreign_obj_type! {
+    type CType = MTLStencilDescriptor;
+    pub struct StencilDescriptor;
+    pub struct StencilDescriptorRef;
+}
+/*
 impl MTLStencilDescriptor {
     pub fn alloc() -> Self {
         unsafe {
@@ -126,11 +129,17 @@ impl NSObjectProtocol for MTLStencilDescriptor {
     unsafe fn class() -> &'static Class {
         Class::get("MTLStencilDescriptor").unwrap()
     }
+}*/
+
+pub enum MTLDepthStencilDescriptor {}
+
+foreign_obj_type! {
+    type CType = MTLDepthStencilDescriptor;
+    pub struct DepthStencilDescriptor;
+    pub struct DepthStencilDescriptorRef;
 }
 
-pub enum MTLDepthStencilDescriptorPrototype {}
-pub type MTLDepthStencilDescriptor = id<(MTLDepthStencilDescriptorPrototype, (NSObjectPrototype, ()))>;
-
+/*
 impl MTLDepthStencilDescriptor {
     pub fn alloc() -> Self {
         unsafe {
@@ -201,14 +210,19 @@ impl NSObjectProtocol for MTLDepthStencilDescriptor {
     unsafe fn class() -> &'static Class {
         Class::get("MTLDepthStencilDescriptor").unwrap()
     }
+}*/
+
+pub enum MTLDepthStencilState {}
+
+foreign_obj_type! {
+    type CType = MTLDepthStencilState;
+    pub struct DepthStencilState;
+    pub struct DepthStencilStateRef;
 }
-
-pub enum MTLDepthStencilStatePrototype {}
-pub type MTLDepthStencilState = id<(MTLDepthStencilStatePrototype, (NSObjectPrototype, ()))>;
-
+/*
 impl NSObjectProtocol for MTLDepthStencilState {
     unsafe fn class() -> &'static Class {
         Class::get("MTLDepthStencilState").unwrap()
     }
-}
+}*/
 

--- a/src/depthstencil.rs
+++ b/src/depthstencil.rs
@@ -38,98 +38,89 @@ foreign_obj_type! {
     pub struct StencilDescriptor;
     pub struct StencilDescriptorRef;
 }
-/*
-impl MTLStencilDescriptor {
-    pub fn alloc() -> Self {
+
+impl StencilDescriptor {
+    pub fn new() -> Self {
         unsafe {
-            msg_send![Self::class(), alloc]
+            let class = Class::get("MTLStencilDescriptor").unwrap();
+            msg_send![class, new]
         }
     }
+}
 
-    pub fn init(&self) -> Self {
-        unsafe {
-            msg_send![self.0, init]
-        }
-    }
-
+impl StencilDescriptorRef {
     pub fn stencil_compare_function(&self) -> MTLCompareFunction {
         unsafe {
-            msg_send![self.0, stencilCompareFunction]
+            msg_send![self, stencilCompareFunction]
         }
     }
 
     pub fn set_stencil_compare_function(&self, func: MTLCompareFunction) {
         unsafe {
-            msg_send![self.0, setStencilCompareFunction:func]
+            msg_send![self, setStencilCompareFunction:func]
         }
     }
 
     pub fn stencil_failure_operation(&self) -> MTLStencilOperation {
         unsafe {
-            msg_send![self.0, stencilFailureOperation]
+            msg_send![self, stencilFailureOperation]
         }
     }
 
     pub fn set_stencil_failure_operation(&self, operation: MTLStencilOperation) {
         unsafe {
-            msg_send![self.0, setStencilFailureOperation:operation]
+            msg_send![self, setStencilFailureOperation:operation]
         }
     }
 
     pub fn depth_failure_operation(&self) -> MTLStencilOperation {
         unsafe {
-            msg_send![self.0, depthFailureOperation]
+            msg_send![self, depthFailureOperation]
         }
     }
 
     pub fn set_depth_failure_operation(&self, operation: MTLStencilOperation) {
         unsafe {
-            msg_send![self.0, setDepthFailureOperation:operation]
+            msg_send![self, setDepthFailureOperation:operation]
         }
     }
 
     pub fn depth_stencil_pass_operation(&self) -> MTLStencilOperation {
         unsafe {
-            msg_send![self.0, depthStencilPassOperation]
+            msg_send![self, depthStencilPassOperation]
         }
     }
 
     pub fn set_depth_stencil_pass_operation(&self, operation: MTLStencilOperation) {
         unsafe {
-            msg_send![self.0, setDepthStencilPassOperation:operation]
+            msg_send![self, setDepthStencilPassOperation:operation]
         }
     }
 
     pub fn read_mask(&self) -> u32 {
         unsafe {
-            msg_send![self.0, readMask]
+            msg_send![self, readMask]
         }
     }
 
     pub fn set_read_mask(&self, mask: u32) {
         unsafe {
-            msg_send![self.0, setReadMask:mask]
+            msg_send![self, setReadMask:mask]
         }
     }
 
     pub fn write_mask(&self) -> u32 {
         unsafe {
-            msg_send![self.0, writeMask]
+            msg_send![self, writeMask]
         }
     }
 
     pub fn set_write_mask(&self, mask: u32) {
         unsafe {
-            msg_send![self.0, setWriteMask:mask]
+            msg_send![self, setWriteMask:mask]
         }
     }
 }
-
-impl NSObjectProtocol for MTLStencilDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLStencilDescriptor").unwrap()
-    }
-}*/
 
 pub enum MTLDepthStencilDescriptor {}
 
@@ -139,35 +130,32 @@ foreign_obj_type! {
     pub struct DepthStencilDescriptorRef;
 }
 
-/*
-impl MTLDepthStencilDescriptor {
-    pub fn alloc() -> Self {
+
+impl DepthStencilDescriptor {
+    pub fn new() -> Self {
         unsafe {
-            msg_send![Self::class(), alloc]
+            let class = Class::get("MTLDepthStencilDescriptor").unwrap();
+            msg_send![class, new]
         }
     }
+}
 
-    pub fn init(&self) -> Self {
-        unsafe {
-            msg_send![self.0, init]
-        }
-    }
-
+impl DepthStencilDescriptorRef {
     pub fn depth_compare_function(&self) -> MTLCompareFunction {
         unsafe {
-            msg_send![self.0, depthCompareFunction]
+            msg_send![self, depthCompareFunction]
         }
     }
 
     pub fn set_depth_compare_function(&self, func: MTLCompareFunction) {
         unsafe {
-            msg_send![self.0, setDepthCompareFunction:func]
+            msg_send![self, setDepthCompareFunction:func]
         }
     }
 
     pub fn depth_write_enabled(&self) -> bool {
         unsafe {
-            match msg_send![self.0, isDepthWriteEnabled] {
+            match msg_send![self, isDepthWriteEnabled] {
                 YES => true,
                 NO => false,
                 _ => unreachable!()
@@ -177,40 +165,34 @@ impl MTLDepthStencilDescriptor {
 
     pub fn set_depth_write_enabled(&self, enabled: bool) {
         unsafe {
-            msg_send![self.0, setDepthWriteEnabled:enabled]
+            msg_send![self, setDepthWriteEnabled:enabled]
         }
     }
 
-    pub fn front_face_stencil(&self) -> MTLStencilDescriptor {
+    pub fn front_face_stencil(&self) -> Option<&StencilDescriptorRef> {
         unsafe {
-            msg_send![self.0, frontFaceStencil]
+            msg_send![self, frontFaceStencil]
         }
     }
 
-    pub fn set_front_face_stencil(&self, descriptor: MTLStencilDescriptor) {
+    pub fn set_front_face_stencil(&self, descriptor: Option<&StencilDescriptorRef>) {
         unsafe {
-            msg_send![self.0, setFrontFaceStencil:descriptor]
+            msg_send![self, setFrontFaceStencil:descriptor]
         }
     }
 
-    pub fn back_face_stencil(&self) -> MTLStencilDescriptor {
+    pub fn back_face_stencil(&self) -> Option<&StencilDescriptorRef> {
         unsafe {
-            msg_send![self.0, backFaceStencil]
+            msg_send![self, backFaceStencil]
         }
     }
 
-    pub fn set_back_face_stencil(&self, descriptor: MTLStencilDescriptor) {
+    pub fn set_back_face_stencil(&self, descriptor: Option<&StencilDescriptorRef>) {
         unsafe {
-            msg_send![self.0, setBackFaceStencil:descriptor]
+            msg_send![self, setBackFaceStencil:descriptor]
         }
     }
 }
-
-impl NSObjectProtocol for MTLDepthStencilDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLDepthStencilDescriptor").unwrap()
-    }
-}*/
 
 pub enum MTLDepthStencilState {}
 
@@ -219,10 +201,3 @@ foreign_obj_type! {
     pub struct DepthStencilState;
     pub struct DepthStencilStateRef;
 }
-/*
-impl NSObjectProtocol for MTLDepthStencilState {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLDepthStencilState").unwrap()
-    }
-}*/
-

--- a/src/drawable.rs
+++ b/src/drawable.rs
@@ -7,11 +7,16 @@
 
 use objc::runtime::Class;
 
-use super::{id, NSObjectPrototype, NSObjectProtocol};
+pub enum MTLDrawable {}
 
-pub enum MTLDrawablePrototype {}
-pub type MTLDrawable = id<(MTLDrawablePrototype, (NSObjectPrototype, ()))>;
+foreign_obj_type! {
+    type CType = MTLDrawable;
+    pub struct Drawable;
+    pub struct DrawableRef;
+}
 
+
+/*
 impl MTLDrawable {
     pub fn present(&self) {
         unsafe {
@@ -25,4 +30,4 @@ impl NSObjectProtocol for MTLDrawable {
         Class::get("MTLDrawable").unwrap()
     }
 }
-
+*/

--- a/src/drawable.rs
+++ b/src/drawable.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use objc::runtime::Class;
-
 pub enum MTLDrawable {}
 
 foreign_obj_type! {
@@ -16,18 +14,10 @@ foreign_obj_type! {
 }
 
 
-/*
-impl MTLDrawable {
+impl DrawableRef {
     pub fn present(&self) {
         unsafe {
-            msg_send![self.0, present]
+            msg_send![self, present]
         }
     }
 }
-
-impl NSObjectProtocol for MTLDrawable {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLDrawable").unwrap()
-    }
-}
-*/

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -9,8 +9,6 @@ use cocoa::foundation::{NSRange, NSUInteger};
 use objc::runtime::Class;
 use objc_foundation::{NSString, INSString};
 
-use super::{id, NSObjectPrototype, NSObjectProtocol};
-
 use libc;
 
 use resource::MTLResource;
@@ -113,11 +111,14 @@ pub struct MTLDrawIndexedPrimitivesIndirectArguments {
     pub baseInstance: u32
 }
 
-pub enum MTLCommandEncoderPrototype {}
-pub type MTLCommandEncoder = id<
-    (MTLCommandEncoderPrototype,
-        (NSObjectPrototype, ()))>;
+pub enum MTLCommandEncoder {}
 
+foreign_obj_type! {
+    type CType = MTLCommandEncoder;
+    pub struct CommandEncoder;
+    pub struct CommandEncoderRef;
+}
+/*
 impl<'a> MTLCommandEncoder {
     pub fn label(&'a self) -> &'a str {
         unsafe {
@@ -144,14 +145,16 @@ impl NSObjectProtocol for MTLCommandEncoder {
     unsafe fn class() -> &'static Class {
         Class::get("MTLCommandEncoder").unwrap()
     }
+}*/
+
+pub enum MTLParallelRenderCommandEncoder {}
+
+foreign_obj_type! {
+    type CType = MTLParallelRenderCommandEncoder;
+    pub struct ParallelRenderCommandEncoder;
+    pub struct ParallelRenderCommandEncoderRef;
 }
-
-pub enum MTLParallelRenderCommandEncoderPrototype {}
-pub type MTLParallelRenderCommandEncoder = id<
-    (MTLParallelRenderCommandEncoderPrototype,
-        (MTLCommandEncoderPrototype,
-            (NSObjectPrototype, ())))>;
-
+/*
 impl MTLParallelRenderCommandEncoder {
     pub fn render_command_encoder(&self) -> MTLRenderCommandEncoder {
         unsafe {
@@ -164,14 +167,16 @@ impl NSObjectProtocol for MTLParallelRenderCommandEncoder {
     unsafe fn class() -> &'static Class {
         Class::get("MTLParallelRenderCommandEncoder").unwrap()
     }
+}*/
+
+pub enum MTLRenderCommandEncoder {}
+
+foreign_obj_type! {
+    type CType = MTLRenderCommandEncoder;
+    pub struct RenderCommandEncoder;
+    pub struct RenderCommandEncoderRef;
 }
-
-pub enum MTLRenderCommandEncoderPrototype {}
-pub type MTLRenderCommandEncoder = id<
-    (MTLRenderCommandEncoderPrototype,
-        (MTLCommandEncoderPrototype,
-            (NSObjectPrototype, ())))>;
-
+/*
 impl MTLRenderCommandEncoder {
     // Setting Graphics Rendering State
 
@@ -398,15 +403,17 @@ impl NSObjectProtocol for MTLRenderCommandEncoder {
     unsafe fn class() -> &'static Class {
         Class::get("MTLRenderCommandEncoder").unwrap()
     }
+}*/
+
+
+pub enum MTLBlitCommandEncoder {}
+
+foreign_obj_type! {
+    type CType = MTLBlitCommandEncoder;
+    pub struct BlitCommandEncoder;
+    pub struct BlitCommandEncoderRef;
 }
-
-
-pub enum MTLBlitCommandEncoderPrototype {}
-pub type MTLBlitCommandEncoder = id<
-    (MTLBlitCommandEncoderPrototype,
-        (MTLCommandEncoderPrototype,
-            (NSObjectPrototype, ())))>;
-
+/*
 impl MTLBlitCommandEncoder {
 
     pub fn synchronize_resource(&self, resource: MTLResource) {
@@ -421,15 +428,17 @@ impl NSObjectProtocol for MTLBlitCommandEncoder {
     unsafe fn class() -> &'static Class {
         Class::get("MTLBlitCommandEncoder").unwrap()
     }
+}*/
+
+
+pub enum MTLComputeCommandEncoder {}
+
+foreign_obj_type! {
+    type CType = MTLComputeCommandEncoder;
+    pub struct ComputeCommandEncoder;
+    pub struct ComputeCommandEncoderRef;
 }
-
-
-pub enum MTLComputeCommandEncoderPrototype {}
-pub type MTLComputeCommandEncoder = id<
-    (MTLComputeCommandEncoderPrototype,
-        (MTLCommandEncoderPrototype,
-            (NSObjectPrototype, ())))>;
-
+/*
 impl MTLComputeCommandEncoder {
 
     pub fn set_render_pipeline_state(&self) {
@@ -441,14 +450,17 @@ impl NSObjectProtocol for MTLComputeCommandEncoder {
     unsafe fn class() -> &'static Class {
         Class::get("MTLComputeCommandEncoder").unwrap()
     }
+}*/
+
+
+pub enum MTLArgumentEncoder {}
+
+foreign_obj_type! {
+    type CType = MTLArgumentEncoder;
+    pub struct ArgumentEncoder;
+    pub struct ArgumentEncoderRef;
 }
-
-
-pub enum MTLArgumentEncoderPrototype {}
-pub type MTLArgumentEncoder = id<
-    (MTLArgumentEncoderPrototype,
-        (NSObjectPrototype, ()))>;
-
+/*
 impl NSObjectProtocol for MTLArgumentEncoder {
     unsafe fn class() -> &'static Class {
         Class::get("MTLArgumentEncoder").unwrap()
@@ -507,4 +519,4 @@ impl MTLArgumentEncoder {
                                      withRange:range]
         }
     }
-}
+}*/

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -5,18 +5,12 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use cocoa::foundation::{NSRange, NSUInteger};
-use objc::runtime::Class;
+use super::*;
+
+use cocoa::foundation::{NSRange, NSUInteger, NSInteger};
 use objc_foundation::{NSString, INSString};
 
 use libc;
-
-use resource::MTLResource;
-use texture::MTLTexture;
-use buffer::MTLBuffer;
-use pipeline::MTLRenderPipelineState;
-use sampler::MTLSamplerState;
-use depthstencil::MTLDepthStencilState;
 
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -118,11 +112,11 @@ foreign_obj_type! {
     pub struct CommandEncoder;
     pub struct CommandEncoderRef;
 }
-/*
-impl<'a> MTLCommandEncoder {
-    pub fn label(&'a self) -> &'a str {
+
+impl CommandEncoderRef {
+    pub fn label(&self) -> &str {
         unsafe {
-            let label: &'a NSString = msg_send![self.0, label];
+            let label: &NSString = msg_send![self, label];
             label.as_str()
         }
     }
@@ -130,22 +124,16 @@ impl<'a> MTLCommandEncoder {
     pub fn set_label(&self, label: &str) {
         unsafe {
             let nslabel = NSString::from_str(label);
-            msg_send![self.0, setLabel:nslabel]
+            msg_send![self, setLabel:nslabel];
         }
     }
 
     pub fn end_encoding(&self) {
         unsafe {
-            msg_send![self.0, endEncoding]
+            msg_send![self, endEncoding];
         }
     }
 }
-
-impl NSObjectProtocol for MTLCommandEncoder {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLCommandEncoder").unwrap()
-    }
-}*/
 
 pub enum MTLParallelRenderCommandEncoder {}
 
@@ -153,21 +141,17 @@ foreign_obj_type! {
     type CType = MTLParallelRenderCommandEncoder;
     pub struct ParallelRenderCommandEncoder;
     pub struct ParallelRenderCommandEncoderRef;
+    type ParentType = CommandEncoderRef;
 }
-/*
-impl MTLParallelRenderCommandEncoder {
-    pub fn render_command_encoder(&self) -> MTLRenderCommandEncoder {
+
+
+impl ParallelRenderCommandEncoderRef {
+    pub fn render_command_encoder(&self) -> &RenderCommandEncoderRef {
         unsafe {
-            msg_send![self.0, renderCommandEncoder]
+            msg_send![self, renderCommandEncoder]
         }
     }
 }
-
-impl NSObjectProtocol for MTLParallelRenderCommandEncoder {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLParallelRenderCommandEncoder").unwrap()
-    }
-}*/
 
 pub enum MTLRenderCommandEncoder {}
 
@@ -175,44 +159,43 @@ foreign_obj_type! {
     type CType = MTLRenderCommandEncoder;
     pub struct RenderCommandEncoder;
     pub struct RenderCommandEncoderRef;
+    type ParentType = CommandEncoderRef;
 }
-/*
-impl MTLRenderCommandEncoder {
-    // Setting Graphics Rendering State
 
-    pub fn set_render_pipeline_state(&self, pipeline_state: MTLRenderPipelineState) {
+impl RenderCommandEncoderRef {
+    pub fn set_render_pipeline_state(&self, pipeline_state: &RenderPipelineStateRef) {
         unsafe {
-            msg_send![self.0, setRenderPipelineState:pipeline_state.0]
+            msg_send![self, setRenderPipelineState:pipeline_state]
         }
     }
 
     pub fn set_viewport(&self, viewport: MTLViewport) {
         unsafe {
-            msg_send![self.0, setViewport:viewport]
+            msg_send![self, setViewport:viewport]
         }
     }
 
     pub fn set_front_facing_winding(&self, winding: MTLWinding) {
         unsafe {
-            msg_send![self.0, setFrontFacingWinding:winding]
+            msg_send![self, setFrontFacingWinding:winding]
         }
     }
 
     pub fn set_cull_mode(&self, mode: MTLCullMode) {
         unsafe {
-            msg_send![self.0, setCullMode:mode]
+            msg_send![self, setCullMode:mode]
         }
     }
 
     pub fn set_depth_clip_mode(&self, mode: MTLDepthClipMode) {
         unsafe {
-            msg_send![self.0, setDepthClipMode:mode]
+            msg_send![self, setDepthClipMode:mode]
         }
     }
 
     pub fn set_depth_bias(&self, bias: f32, scale: f32, clamp: f32) {
         unsafe {
-            msg_send![self.0, setDepthBias:bias
+            msg_send![self, setDepthBias:bias
                               slopeScale:scale
                                    clamp:clamp]
         }
@@ -220,86 +203,86 @@ impl MTLRenderCommandEncoder {
 
     pub fn set_scissor_rect(&self, rect: MTLScissorRect) {
         unsafe {
-            msg_send![self.0, setScissorRect:rect]
+            msg_send![self, setScissorRect:rect]
         }
     }
 
     pub fn set_triangle_fill_mode(&self, mode: MTLTriangleFillMode) {
         unsafe {
-            msg_send![self.0, setTriangleFillMode:mode]
+            msg_send![self, setTriangleFillMode:mode]
         }
     }
 
     pub fn set_blend_color(&self, red: f32, green: f32, blue: f32, alpha: f32) {
         unsafe {
-            msg_send![self.0, setBlendColorRed:red
+            msg_send![self, setBlendColorRed:red
                                          green:green
                                           blue:blue
                                          alpha:alpha]
         }
     }
 
-    pub fn set_depth_stencil_state(&self, depth_stencil_state: MTLDepthStencilState) {
+    pub fn set_depth_stencil_state(&self, depth_stencil_state: &DepthStencilStateRef) {
         unsafe {
-            msg_send![self.0, setDepthStencilState:depth_stencil_state.0]
+            msg_send![self, setDepthStencilState:depth_stencil_state]
         }
     }
 
     pub fn set_stencil_reference_value(&self, value: u32) {
         unsafe {
-            msg_send![self.0, setStencilReferenceValue:value]
+            msg_send![self, setStencilReferenceValue:value]
         }
     }
 
     pub fn set_stencil_front_back_reference_value(&self, front: u32, back: u32) {
         unsafe {
-            msg_send![self.0, setStencilFrontReferenceValue:front
-                                         backReferenceValue:back]
+            msg_send![self, setStencilFrontReferenceValue:front
+                                       backReferenceValue:back]
         }
     }
 
-    pub fn set_visibility_result_mode(&self, offset: u64, mode: MTLVisibilityResultMode) {
+    pub fn set_visibility_result_mode(&self, offset: NSUInteger, mode: MTLVisibilityResultMode) {
         unsafe {
-            msg_send![self.0, setVisibilityResultMode:mode
-                                               offset:offset]
+            msg_send![self, setVisibilityResultMode:mode
+                                             offset:offset]
         }
     }
 
     // Specifying Resources for a Vertex Shader Function
 
-    pub fn set_vertex_bytes(&self, index: u64, length: u64, bytes: *const libc::c_void) {
+    pub fn set_vertex_bytes(&self, index: NSUInteger, length: NSUInteger, bytes: *const libc::c_void) {
         unsafe {
-            msg_send![self.0, setVertexBytes:bytes
-                                      length:length
-                                     atIndex:index]
+            msg_send![self, setVertexBytes:bytes
+                                    length:length
+                                   atIndex:index]
         }
     }
 
-    pub fn set_vertex_buffer(&self, index: u64, offset: u64, buffer: MTLBuffer) {
+    pub fn set_vertex_buffer(&self, index: NSUInteger, offset: NSUInteger, buffer: &BufferRef) {
         unsafe {
-            msg_send![self.0, setVertexBuffer:buffer.0
+            msg_send![self, setVertexBuffer:buffer
                                        offset:offset
                                       atIndex:index]
         }
     }
 
-    pub fn set_vertex_texture(&self, index: u64, texture: MTLTexture) {
+    pub fn set_vertex_texture(&self, index: u64, texture: &TextureRef) {
         unsafe {
-            msg_send![self.0, setVertexTexture:texture.0
+            msg_send![self, setVertexTexture:texture
                                        atIndex:index]
         }
     }
 
-    pub fn set_vertex_sampler_state(&self, index: u64, sampler: MTLSamplerState) {
+    pub fn set_vertex_sampler_state(&self, index: u64, sampler: &SamplerState) {
         unsafe {
-            msg_send![self.0, setVertexSamplerState:sampler.0
-                                            atIndex:index]
+            msg_send![self, setVertexSamplerState:sampler
+                                          atIndex:index]
         }
     }
 
-    pub fn set_vertex_sampler_state_with_lod(&self, index: u64, lod_min_clamp: f32, lod_max_clamp: f32, sampler: MTLSamplerState) {
+    pub fn set_vertex_sampler_state_with_lod(&self, index: NSUInteger, lod_min_clamp: f32, lod_max_clamp: f32, sampler: &SamplerState) {
         unsafe {
-            msg_send![self.0, setVertexSamplerState:sampler.0
+            msg_send![self, setVertexSamplerState:sampler
                                         lodMinClamp:lod_min_clamp
                                         lodMaxClamp:lod_max_clamp
                                             atIndex:index]
@@ -308,39 +291,39 @@ impl MTLRenderCommandEncoder {
 
     // Specifying Resources for a Fragment Shader Function
 
-    pub fn set_fragment_bytes(&self, index: u64, length: u64, bytes: *const libc::c_void) {
+    pub fn set_fragment_bytes(&self, index: NSUInteger, length: NSUInteger, bytes: *const libc::c_void) {
         unsafe {
-            msg_send![self.0, setFragmentBytes:bytes
+            msg_send![self, setFragmentBytes:bytes
                                         length:length
                                        atIndex:index]
         }
     }
 
-    pub fn set_fragment_buffer(&self, index: u64, offset: u64, buffer: MTLBuffer) {
+    pub fn set_fragment_buffer(&self, index: NSUInteger, offset: NSUInteger, buffer: MTLBuffer) {
         unsafe {
-            msg_send![self.0, setFragmentBuffer:buffer.0
-                                         offset:offset
-                                        atIndex:index]
+            msg_send![self, setFragmentBuffer:buffer
+                                       offset:offset
+                                      atIndex:index]
         }
     }
 
-    pub fn set_fragment_texture(&self, index: u64, texture: MTLTexture) {
+    pub fn set_fragment_texture(&self, index: NSUInteger, texture: &TextureRef) {
         unsafe {
-            msg_send![self.0, setFragmentTexture:texture.0
-                                         atIndex:index]
+            msg_send![self, setFragmentTexture:texture
+                                       atIndex:index]
         }
     }
 
-    pub fn set_fragment_sampler_state(&self, index: u64, sampler: MTLSamplerState) {
+    pub fn set_fragment_sampler_state(&self, index: NSUInteger, sampler: MTLSamplerState) {
         unsafe {
-            msg_send![self.0, setFragmentSamplerState:sampler.0
-                                              atIndex:index]
+            msg_send![self, setFragmentSamplerState:sampler
+                                            atIndex:index]
         }
     }
 
-    pub fn set_fragment_sampler_state_with_lod(&self, index: u64, lod_min_clamp: f32, lod_max_clamp: f32, sampler: MTLSamplerState) {
+    pub fn set_fragment_sampler_state_with_lod(&self, index: NSUInteger, lod_min_clamp: f32, lod_max_clamp: f32, sampler: MTLSamplerState) {
         unsafe {
-            msg_send![self.0, setFragmentSamplerState:sampler.0
+            msg_send![self, setFragmentSamplerState:sampler
                                           lodMinClamp:lod_min_clamp
                                           lodMaxClamp:lod_max_clamp
                                               atIndex:index]
@@ -349,39 +332,39 @@ impl MTLRenderCommandEncoder {
 
     // Drawing Geometric Primitives
 
-    pub fn draw_primitives(&self, primitive_type: MTLPrimitiveType, vertex_start: u64, vertex_count: u64) {
+    pub fn draw_primitives(&self, primitive_type: MTLPrimitiveType, vertex_start: NSUInteger, vertex_count: NSUInteger) {
         unsafe {
-            msg_send![self.0, drawPrimitives:primitive_type
-                                 vertexStart:vertex_start
-                                 vertexCount:vertex_count]
+            msg_send![self, drawPrimitives:primitive_type
+                               vertexStart:vertex_start
+                               vertexCount:vertex_count]
         }
     }
 
-    pub fn draw_primitives_instanced(&self, primitive_type: MTLPrimitiveType, vertex_start: u64, vertex_count: u64, instance_count: u64) {
+    pub fn draw_primitives_instanced(&self, primitive_type: MTLPrimitiveType, vertex_start: NSUInteger, vertex_count: NSUInteger, instance_count: NSUInteger) {
         unsafe {
-            msg_send![self.0, drawPrimitives:primitive_type
+            msg_send![self, drawPrimitives:primitive_type
                                  vertexStart:vertex_start
                                  vertexCount:vertex_count
                                instanceCount:instance_count]
         }
     }
 
-    pub fn draw_indexed_primitives(&self, primitive_type: MTLPrimitiveType, index_count: u64, index_type: MTLIndexType, index_buffer: MTLBuffer, index_buffer_offset: u64) {
+    pub fn draw_indexed_primitives(&self, primitive_type: MTLPrimitiveType, index_count: NSUInteger, index_type: MTLIndexType, index_buffer: &BufferRef, index_buffer_offset: NSUInteger) {
         unsafe {
-            msg_send![self.0, drawIndexedPrimitives:primitive_type
+            msg_send![self, drawIndexedPrimitives:primitive_type
                                          indexCount:index_count
                                           indexType:index_type
-                                        indexBuffer:index_buffer.0
+                                        indexBuffer:index_buffer
                                   indexBufferOffset:index_buffer_offset]
         }
     }
 
-    pub fn draw_indexed_primitives_instanced(&self, primitive_type: MTLPrimitiveType, index_count: u64, index_type: MTLIndexType, index_buffer: MTLBuffer, index_buffer_offset: u64, instance_count: u64, base_vertex: i64, base_instance: u64) {
+    pub fn draw_indexed_primitives_instanced(&self, primitive_type: MTLPrimitiveType, index_count: NSUInteger, index_type: MTLIndexType, index_buffer: &BufferRef, index_buffer_offset: NSUInteger, instance_count: NSUInteger, base_vertex: NSInteger, base_instance: NSUInteger) {
         unsafe {
-            msg_send![self.0, drawIndexedPrimitives:primitive_type
+            msg_send![self, drawIndexedPrimitives:primitive_type
                                          indexCount:index_count
                                           indexType:index_type
-                                        indexBuffer:index_buffer.0
+                                        indexBuffer:index_buffer
                                   indexBufferOffset:index_buffer_offset
                                       instanceCount:instance_count
                                          baseVertex:base_vertex
@@ -399,37 +382,23 @@ impl MTLRenderCommandEncoder {
  
 }
 
-impl NSObjectProtocol for MTLRenderCommandEncoder {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLRenderCommandEncoder").unwrap()
-    }
-}*/
-
-
 pub enum MTLBlitCommandEncoder {}
 
 foreign_obj_type! {
     type CType = MTLBlitCommandEncoder;
     pub struct BlitCommandEncoder;
     pub struct BlitCommandEncoderRef;
+    type ParentType = CommandEncoderRef;
 }
-/*
-impl MTLBlitCommandEncoder {
 
-    pub fn synchronize_resource(&self, resource: MTLResource) {
+impl BlitCommandEncoderRef {
+    pub fn synchronize_resource(&self, resource: &ResourceRef) {
         unsafe {
-            msg_send![self.0, synchronizeResource:resource]
+            msg_send![self, synchronizeResource:resource]
         }
     }
 
 }
-
-impl NSObjectProtocol for MTLBlitCommandEncoder {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLBlitCommandEncoder").unwrap()
-    }
-}*/
-
 
 pub enum MTLComputeCommandEncoder {}
 
@@ -437,21 +406,8 @@ foreign_obj_type! {
     type CType = MTLComputeCommandEncoder;
     pub struct ComputeCommandEncoder;
     pub struct ComputeCommandEncoderRef;
+    type ParentType = CommandEncoderRef;
 }
-/*
-impl MTLComputeCommandEncoder {
-
-    pub fn set_render_pipeline_state(&self) {
-    }
-
-}
-
-impl NSObjectProtocol for MTLComputeCommandEncoder {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLComputeCommandEncoder").unwrap()
-    }
-}*/
-
 
 pub enum MTLArgumentEncoder {}
 
@@ -460,63 +416,57 @@ foreign_obj_type! {
     pub struct ArgumentEncoder;
     pub struct ArgumentEncoderRef;
 }
-/*
-impl NSObjectProtocol for MTLArgumentEncoder {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLArgumentEncoder").unwrap()
-    }
-}
 
-impl MTLArgumentEncoder {
+impl ArgumentEncoderRef {
     pub fn encoded_length(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, encodedLength]
+            msg_send![self, encodedLength]
         }
     }
 
     pub fn alignment(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, alignment]
+            msg_send![self, alignment]
         }
     }
 
-    pub fn set_argument_buffer(&self, buffer: MTLBuffer, offset: NSUInteger) {
+    pub fn set_argument_buffer(&self, buffer: &BufferRef, offset: NSUInteger) {
         unsafe {
-            msg_send![self.0, setArgumentBuffer:buffer
-                                         offset:offset]
+            msg_send![self, setArgumentBuffer:buffer
+                                       offset:offset]
         }
     }
 
-    pub fn set_buffers(&self, data: &[MTLBuffer], offset: NSUInteger) {
+    pub fn set_buffers(&self, data: &[Buffer], offset: NSUInteger) {
         let range = NSRange {
             location: offset,
             length: data.len() as NSUInteger,
         };
         unsafe {
-            msg_send![self.0, setBuffers:data.as_ptr()
-                               withRange:range]
+            msg_send![self, setBuffers:data.as_ptr()
+                             withRange:range]
         }
     }
 
-    pub fn set_textures(&self, data: &[MTLTexture], offset: NSUInteger) {
+    pub fn set_textures(&self, data: &[Texture], offset: NSUInteger) {
         let range = NSRange {
             location: offset,
             length: data.len() as NSUInteger,
         };
         unsafe {
-            msg_send![self.0, setTextures:data.as_ptr()
-                                withRange:range]
+            msg_send![self, setTextures:data.as_ptr()
+                              withRange:range]
         }
     }
 
-    pub fn set_sampler_states(&self, data: &[MTLSamplerState], offset: NSUInteger) {
+    pub fn set_sampler_states(&self, data: &[&SamplerStateRef], offset: NSUInteger) {
         let range = NSRange {
             location: offset,
             length: data.len() as NSUInteger,
         };
         unsafe {
-            msg_send![self.0, setSamplerStates:data.as_ptr()
-                                     withRange:range]
+            msg_send![self, setSamplerStates:data.as_ptr()
+                                   withRange:range]
         }
     }
-}*/
+}

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -5,7 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use {NSObjectPrototype, NSObjectProtocol, id};
 use buffer::MTLBuffer;
 use texture::{MTLTexture, MTLTextureDescriptor};
 use resource::{MTLResourceOptions, MTLStorageMode, MTLCPUCacheMode, MTLPurgeableState};
@@ -13,9 +12,14 @@ use resource::{MTLResourceOptions, MTLStorageMode, MTLCPUCacheMode, MTLPurgeable
 use cocoa::foundation::NSUInteger;
 use objc::runtime::Class;
 
-pub enum MTLHeapPrototype {}
-pub type MTLHeap = id<(MTLHeapPrototype, (NSObjectPrototype, ()))>;
+pub enum MTLHeap {}
 
+foreign_obj_type! {
+    type CType = MTLHeap;
+    pub struct Heap;
+    pub struct HeapRef;
+}
+/*
 impl MTLHeap {
     pub fn cpu_cache_mode(&self) -> MTLCPUCacheMode {
         unsafe {
@@ -65,16 +69,16 @@ impl MTLHeap {
             msg_send![self.0, newTextureWithDescriptor:descriptor.0]
         }
     }
-}
-pub enum MTLHeapDescriptorPrototype {}
-pub type MTLHeapDescriptor = id<(MTLHeapDescriptorPrototype, (NSObjectPrototype, ()))>;
+}*/
 
-impl NSObjectProtocol for MTLHeapDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLHeapDescriptor").unwrap()
-    }
-}
+pub enum MTLHeapDescriptor {}
 
+foreign_obj_type! {
+    type CType = MTLHeapDescriptor;
+    pub struct HeapDescriptor;
+    pub struct HeapDescriptorRef;
+}
+/*
 impl MTLHeapDescriptor {
     pub fn new() -> Self {
         unsafe {
@@ -129,4 +133,4 @@ impl MTLHeapDescriptor {
             msg_send![self.0, setSize: size];
         }
     }
-}
+}*/

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -5,9 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use buffer::MTLBuffer;
-use texture::{MTLTexture, MTLTextureDescriptor};
-use resource::{MTLResourceOptions, MTLStorageMode, MTLCPUCacheMode, MTLPurgeableState};
+use super::*;
 
 use cocoa::foundation::NSUInteger;
 use objc::runtime::Class;
@@ -19,57 +17,57 @@ foreign_obj_type! {
     pub struct Heap;
     pub struct HeapRef;
 }
-/*
-impl MTLHeap {
+
+impl HeapRef {
     pub fn cpu_cache_mode(&self) -> MTLCPUCacheMode {
         unsafe {
-            msg_send![self.0, cpuCacheMode]
+            msg_send![self, cpuCacheMode]
         }
     }
 
     pub fn storage_mode(&self) -> MTLStorageMode {
         unsafe {
-            msg_send![self.0, storageMode]
+            msg_send![self, storageMode]
         }
     }
 
     pub fn set_purgeable_state(&self, state: MTLPurgeableState) -> MTLPurgeableState {
         unsafe {
-            msg_send![self.0, setPurgeableState:state]
+            msg_send![self, setPurgeableState:state]
         }
     }
 
     pub fn size(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, size]
+            msg_send![self, size]
         }
     }
 
     pub fn used_size(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, usedSize]
+            msg_send![self, usedSize]
         }
     }
 
     pub fn max_available_size(&self, alignment: NSUInteger) -> NSUInteger {
         unsafe {
-            msg_send![self.0, maxAvailableSize: alignment]
+            msg_send![self, maxAvailableSize: alignment]
         }
     }
 
-    pub fn new_buffer(&self, length: u64, options: MTLResourceOptions) -> MTLBuffer {
+    pub fn new_buffer(&self, length: u64, options: MTLResourceOptions) -> Buffer {
         unsafe {
-            msg_send![self.0, newBufferWithLength:length
-                                          options:options]
+            msg_send![self, newBufferWithLength:length
+                                        options:options]
         }
     }
 
-    pub fn new_texture(&self, descriptor: MTLTextureDescriptor) -> MTLTexture {
+    pub fn new_texture(&self, descriptor: &TextureDescriptorRef) -> Texture {
         unsafe {
-            msg_send![self.0, newTextureWithDescriptor:descriptor.0]
+            msg_send![self, newTextureWithDescriptor:descriptor]
         }
     }
-}*/
+}
 
 pub enum MTLHeapDescriptor {}
 
@@ -78,59 +76,50 @@ foreign_obj_type! {
     pub struct HeapDescriptor;
     pub struct HeapDescriptorRef;
 }
-/*
-impl MTLHeapDescriptor {
+
+impl HeapDescriptor {
     pub fn new() -> Self {
         unsafe {
-            msg_send![Self::class(), new]
+            let class = Class::get("MTLHeapDescriptor").unwrap();
+            msg_send![class, new]
         }
     }
+}
 
-    pub fn alloc() -> Self {
-        unsafe {
-            msg_send![Self::class(), alloc]
-        }
-    }
-
-    pub fn init(&self) -> Self {
-        unsafe {
-            msg_send![self.0, init]
-        }
-    }
-
+impl HeapDescriptorRef {
     pub fn cpu_cache_mode(&self) -> MTLCPUCacheMode {
         unsafe {
-            msg_send![self.0, cpuCacheMode]
+            msg_send![self, cpuCacheMode]
         }
     }
 
     pub fn set_cpu_cache_mode(&self, mode: MTLCPUCacheMode) {
         unsafe {
-            msg_send![self.0, setCpuCacheMode:mode]
+            msg_send![self, setCpuCacheMode:mode]
         }
     }
 
     pub fn storage_mode(&self) -> MTLStorageMode {
         unsafe {
-            msg_send![self.0, storageMode]
+            msg_send![self, storageMode]
         }
     }
 
     pub fn set_storage_mode(&self, mode: MTLStorageMode) {
         unsafe {
-            msg_send![self.0, setStorageMode:mode]
+            msg_send![self, setStorageMode:mode]
         }
     }
 
     pub fn size(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, size]
+            msg_send![self, size]
         }
     }
 
     pub fn set_size(&self, size: NSUInteger) {
         unsafe {
-            msg_send![self.0, setSize: size];
+            msg_send![self, setSize: size];
         }
     }
-}*/
+}

--- a/src/library.rs
+++ b/src/library.rs
@@ -8,13 +8,16 @@
 use objc::runtime::{Class, YES, NO};
 use objc_foundation::{NSString, INSString};
 
-use super::{id, NSObjectPrototype, NSObjectProtocol, NSArray};
-
 use argument::MTLDataType;
 
-pub enum MTLVertexAttributePrototype {}
-pub type MTLVertexAttribute = id<(MTLVertexAttributePrototype, (NSObjectPrototype, ()))>;
+pub enum MTLVertexAttribute {}
 
+foreign_obj_type! {
+    type CType = MTLVertexAttribute;
+    pub struct VertexAttribute;
+    pub struct VertexAttributeRef;
+}
+/*
 impl<'a> MTLVertexAttribute {
     pub fn name(&'a self) -> &'a str {
         unsafe {
@@ -51,7 +54,7 @@ impl NSObjectProtocol for MTLVertexAttribute {
     unsafe fn class() -> &'static Class {
         Class::get("MTLVertexAttribute").unwrap()
     }
-}
+}*/
 
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -61,11 +64,14 @@ pub enum MTLFunctionType {
     Kernel = 3,
 }
 
+pub enum MTLFunction {}
 
-
-pub enum MTLFunctionPrototype {}
-pub type MTLFunction = id<(MTLFunctionPrototype, (NSObjectPrototype, ()))>;
-
+foreign_obj_type! {
+    type CType = MTLFunction;
+    pub struct Function;
+    pub struct FunctionRef;
+}
+/*
 impl<'a> MTLFunction {
     pub fn name(&'a self) -> &'a str {
         unsafe {
@@ -91,7 +97,7 @@ impl NSObjectProtocol for MTLFunction {
     unsafe fn class() -> &'static Class {
         Class::get("MTLFunction").unwrap()
     }
-}
+}*/
 
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -103,9 +109,14 @@ pub enum MTLLanguageVersion {
 }
 
 
-pub enum MTLCompileOptionsPrototype {}
-pub type MTLCompileOptions = id<(MTLCompileOptionsPrototype, (NSObjectPrototype, ()))>;
+pub enum MTLCompileOptions {}
 
+foreign_obj_type! {
+    type CType = MTLCompileOptions;
+    pub struct CompileOptions;
+    pub struct CompileOptionsRef;
+}
+/*
 impl MTLCompileOptions {
     pub fn new() -> Self {
         unsafe {
@@ -170,7 +181,7 @@ impl NSObjectProtocol for MTLCompileOptions {
     unsafe fn class() -> &'static Class {
         Class::get("MTLCompileOptions").unwrap()
     }
-}
+}*/
 
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -189,11 +200,14 @@ pub enum MTLRenderPipelineError {
     InvalidInput      = 3,
 }
 
+pub enum MTLLibrary {}
 
-
-pub enum MTLLibraryPrototype {}
-pub type MTLLibrary = id<(MTLLibraryPrototype, (NSObjectPrototype, ()))>;
-
+foreign_obj_type! {
+    type CType = MTLLibrary;
+    pub struct Library;
+    pub struct LibraryRef;
+}
+/*
 impl<'a> MTLLibrary {
     pub fn label(&'a self) -> &'a str {
         unsafe {
@@ -233,5 +247,5 @@ impl NSObjectProtocol for MTLLibrary {
     unsafe fn class() -> &'static Class {
         Class::get("MTLLibrary").unwrap()
     }
-}
+}*/
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -9,14 +9,12 @@ use cocoa::foundation::NSUInteger;
 use objc::runtime::{Class, YES, NO};
 use objc_foundation::{INSString, NSString};
 
-use super::{id, NSObjectPrototype, NSObjectProtocol, NSArray};
-
 use libc;
 
 use device::MTLDevice;
 use constants::MTLPixelFormat;
 use library::MTLFunction;
-use argument::MTLArgument;
+//use argument::MTLArgument;
 use vertexdescriptor::MTLVertexDescriptor;
 
 #[repr(u64)]
@@ -69,9 +67,14 @@ pub enum MTLPrimitiveTopologyClass {
     Triangle = 3,
 }
 
-pub enum MTLRenderPipelineColorAttachmentDescriptorPrototype {}
-pub type MTLRenderPipelineColorAttachmentDescriptor = id<(MTLRenderPipelineColorAttachmentDescriptorPrototype, (NSObjectPrototype, ()))>;
+pub enum MTLRenderPipelineColorAttachmentDescriptor {}
 
+foreign_obj_type! {
+    type CType = MTLRenderPipelineColorAttachmentDescriptor;
+    pub struct RenderPipelineColorAttachmentDescriptor;
+    pub struct RenderPipelineColorAttachmentDescriptorRef;
+}
+/*
 impl MTLRenderPipelineColorAttachmentDescriptor {
     pub fn pixel_format(&self) -> MTLPixelFormat {
         unsafe {
@@ -190,11 +193,16 @@ impl NSObjectProtocol for MTLRenderPipelineColorAttachmentDescriptor {
     unsafe fn class() -> &'static Class {
         Class::get("MTLRenderPipelineColorAttachmentDescriptor").unwrap()
     }
+}*/
+
+pub enum MTLRenderPipelineReflection {}
+
+foreign_obj_type! {
+    type CType = MTLRenderPipelineReflection;
+    pub struct RenderPipelineReflection;
+    pub struct RenderPipelineReflectionRef;
 }
-
-pub enum MTLRenderPipelineReflectionPrototype {}
-pub type MTLRenderPipelineReflection = id<(MTLRenderPipelineReflectionPrototype, (NSObjectPrototype, ()))>;
-
+/*
 impl MTLRenderPipelineReflection {
     pub fn alloc() -> Self {
         unsafe {
@@ -233,11 +241,16 @@ impl NSObjectProtocol for MTLRenderPipelineReflection {
     unsafe fn class() -> &'static Class {
         Class::get("MTLRenderPipelineReflectionInternal").unwrap()
     }
+}*/
+
+pub enum MTLRenderPipelineDescriptor {}
+
+foreign_obj_type! {
+    type CType = MTLRenderPipelineDescriptor;
+    pub struct RenderPipelineDescriptor;
+    pub struct RenderPipelineDescriptorRef;
 }
-
-pub enum MTLRenderPipelineDescriptorPrototype {}
-pub type MTLRenderPipelineDescriptor = id<(MTLRenderPipelineDescriptorPrototype, (NSObjectPrototype, ()))>;
-
+/*
 impl<'a> MTLRenderPipelineDescriptor {
     pub fn alloc() -> Self {
         unsafe {
@@ -424,11 +437,16 @@ impl NSObjectProtocol for MTLRenderPipelineDescriptor {
     unsafe fn class() -> &'static Class {
         Class::get("MTLRenderPipelineDescriptorInternal").unwrap()
     }
+}*/
+
+pub enum MTLRenderPipelineState {}
+
+foreign_obj_type! {
+    type CType = MTLRenderPipelineState;
+    pub struct RenderPipelineState;
+    pub struct RenderPipelineStateRef;
 }
-
-pub enum MTLRenderPipelineStatePrototype {}
-pub type MTLRenderPipelineState = id<(MTLRenderPipelineStatePrototype, (NSObjectPrototype, ()))>;
-
+/*
 impl<'a> MTLRenderPipelineState {
     pub fn label(&'a self) -> &'a str {
         unsafe {
@@ -449,11 +467,16 @@ impl NSObjectProtocol for MTLRenderPipelineState {
     unsafe fn class() -> &'static Class {
         Class::get("MTLRenderPipelineState").unwrap()
     }
+}*/
+
+pub enum MTLRenderPipelineColorAttachmentDescriptorArray {}
+
+foreign_obj_type! {
+    type CType = MTLRenderPipelineColorAttachmentDescriptorArray;
+    pub struct RenderPipelineColorAttachmentDescriptorArray;
+    pub struct RenderPipelineColorAttachmentDescriptorArrayRef;
 }
-
-pub enum MTLRenderPipelineColorAttachmentDescriptorArrayPrototype {}
-pub type MTLRenderPipelineColorAttachmentDescriptorArray = id<(MTLRenderPipelineColorAttachmentDescriptorArrayPrototype, (NSObjectPrototype, ()))>;
-
+/*
 impl MTLRenderPipelineColorAttachmentDescriptorArray {
     pub fn object_at(&self, index: usize) -> MTLRenderPipelineColorAttachmentDescriptor {
         unsafe {
@@ -473,5 +496,5 @@ impl NSObjectProtocol for MTLRenderPipelineColorAttachmentDescriptorArray {
     unsafe fn class() -> &'static Class {
         Class::get("MTLRenderPipelineColorAttachmentDescriptorArray").unwrap()
     }
-}
+}*/
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -5,17 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use super::*;
+
 use cocoa::foundation::NSUInteger;
-use objc::runtime::{Class, YES, NO};
+use objc::runtime::{Class, Object, YES, NO};
 use objc_foundation::{INSString, NSString};
 
 use libc;
-
-use device::MTLDevice;
-use constants::MTLPixelFormat;
-use library::MTLFunction;
-//use argument::MTLArgument;
-use vertexdescriptor::MTLVertexDescriptor;
 
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -74,23 +70,23 @@ foreign_obj_type! {
     pub struct RenderPipelineColorAttachmentDescriptor;
     pub struct RenderPipelineColorAttachmentDescriptorRef;
 }
-/*
-impl MTLRenderPipelineColorAttachmentDescriptor {
+
+impl RenderPipelineColorAttachmentDescriptorRef {
     pub fn pixel_format(&self) -> MTLPixelFormat {
         unsafe {
-            msg_send![self.0, pixelFormat]
+            msg_send![self, pixelFormat]
         }
     }
 
     pub fn set_pixel_format(&self, pixel_format: MTLPixelFormat) {
         unsafe {
-            msg_send![self.0, setPixelFormat:pixel_format]
+            msg_send![self, setPixelFormat:pixel_format]
         }
     }
 
     pub fn is_blending_enabled(&self) -> bool {
         unsafe {
-            match msg_send![self.0, isBlendingEnabled] {
+            match msg_send![self, isBlendingEnabled] {
                 YES => true,
                 NO => false,
                 _ => unreachable!()
@@ -100,100 +96,94 @@ impl MTLRenderPipelineColorAttachmentDescriptor {
 
     pub fn set_blending_enabled(&self, enabled: bool) {
         unsafe {
-            msg_send![self.0, setBlendingEnabled:enabled]
+            msg_send![self, setBlendingEnabled:enabled]
         }
     }
 
     pub fn source_rgb_blend_factor(&self) -> MTLBlendFactor {
         unsafe {
-            msg_send![self.0, sourceRGBBlendFactor]
+            msg_send![self, sourceRGBBlendFactor]
         }
     }
 
     pub fn set_source_rgb_blend_factor(&self, blend_factor: MTLBlendFactor) {
         unsafe {
-            msg_send![self.0, setSourceRGBBlendFactor:blend_factor]
+            msg_send![self, setSourceRGBBlendFactor:blend_factor]
         }
     }
 
     pub fn destination_rgb_blend_factor(&self) -> MTLBlendFactor {
         unsafe {
-            msg_send![self.0, destinationRGBBlendFactor]
+            msg_send![self, destinationRGBBlendFactor]
         }
     }
 
     pub fn set_destination_rgb_blend_factor(&self, blend_factor: MTLBlendFactor) {
         unsafe {
-            msg_send![self.0, setDestinationRGBBlendFactor:blend_factor]
+            msg_send![self, setDestinationRGBBlendFactor:blend_factor]
         }
     }
 
     pub fn rgb_blend_operation(&self) -> MTLBlendOperation {
         unsafe {
-            msg_send![self.0, rgbBlendOperation]
+            msg_send![self, rgbBlendOperation]
         }
     }
 
     pub fn set_rgb_blend_operation(&self, blend_operation: MTLBlendOperation) {
         unsafe {
-            msg_send![self.0, setRgbBlendOperation:blend_operation]
+            msg_send![self, setRgbBlendOperation:blend_operation]
         }
     }
 
     pub fn source_alpha_blend_factor(&self) -> MTLBlendFactor {
         unsafe {
-            msg_send![self.0, sourceAlphaBlendFactor]
+            msg_send![self, sourceAlphaBlendFactor]
         }
     }
 
     pub fn set_source_alpha_blend_factor(&self, blend_factor: MTLBlendFactor) {
         unsafe {
-            msg_send![self.0, setSourceAlphaBlendFactor:blend_factor]
+            msg_send![self, setSourceAlphaBlendFactor:blend_factor]
         }
     }
 
     pub fn destination_alpha_blend_factor(&self) -> MTLBlendFactor {
         unsafe {
-            msg_send![self.0, destinationAlphaBlendFactor]
+            msg_send![self, destinationAlphaBlendFactor]
         }
     }
 
     pub fn set_destination_alpha_blend_factor(&self, blend_factor: MTLBlendFactor) {
         unsafe {
-            msg_send![self.0, setDestinationAlphaBlendFactor:blend_factor]
+            msg_send![self, setDestinationAlphaBlendFactor:blend_factor]
         }
     }
 
     pub fn alpha_blend_operation(&self) -> MTLBlendOperation {
         unsafe {
-            msg_send![self.0, alphaBlendOperation]
+            msg_send![self, alphaBlendOperation]
         }
     }
 
     pub fn set_alpha_blend_operation(&self, blend_operation: MTLBlendOperation) {
         unsafe {
-            msg_send![self.0, setAlphaBlendOperation:blend_operation]
+            msg_send![self, setAlphaBlendOperation:blend_operation]
         }
     }
 
     pub fn write_mask(&self) -> MTLColorWriteMask {
         unsafe {
-            msg_send![self.0, writeMask]
+            msg_send![self, writeMask]
         }
     }
 
     pub fn set_write_mask(&self, mask: MTLColorWriteMask) {
         unsafe {
-            msg_send![self.0, setWriteMask:mask]
+            msg_send![self, setWriteMask:mask]
         }
     }
 }
-
-impl NSObjectProtocol for MTLRenderPipelineColorAttachmentDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLRenderPipelineColorAttachmentDescriptor").unwrap()
-    }
-}*/
 
 pub enum MTLRenderPipelineReflection {}
 
@@ -202,46 +192,40 @@ foreign_obj_type! {
     pub struct RenderPipelineReflection;
     pub struct RenderPipelineReflectionRef;
 }
-/*
-impl MTLRenderPipelineReflection {
-    pub fn alloc() -> Self {
-        unsafe {
-            msg_send![Self::class(), alloc]
-        }
-    }
 
-    pub fn init(&self, vertex_data: *mut libc::c_void,
+impl RenderPipelineReflection {
+    pub unsafe fn new(vertex_data: *mut libc::c_void,
             fragment_data: *mut libc::c_void, vertex_desc: *mut libc::c_void,
-            device: MTLDevice, options: u64, flags: u64) -> Self {
-        unsafe {
-            println!("{:p}, {:p}, {:p}, {:?}, {:?}, {:?}", vertex_data, fragment_data, vertex_desc, device, options, flags);
-            msg_send![self.0, initWithVertexData:vertex_data
-                                    fragmentData:fragment_data
-                      serializedVertexDescriptor:vertex_desc
-                                          device:device.0
-                                         options:options
-                                           flags:flags]
+            device: &DeviceRef, options: u64, flags: u64) -> Self
+    {
+        let class = Class::get("MTLRenderPipelineReflection").unwrap();
+        let this: RenderPipelineReflection = msg_send![class, alloc];
+        let this_alias: *mut Object = msg_send![this.as_ref(), initWithVertexData:vertex_data
+                                                                fragmentData:fragment_data
+                                                serializedVertexDescriptor:vertex_desc
+                                                                    device:device
+                                                                    options:options
+                                                                        flags:flags];
+        if this_alias.is_null() {
+            panic!("[MTLRenderPipelineReflection init] failed");
         }
-    }
-
-    pub fn fragment_arguments(&self) -> NSArray<MTLArgument> {
-        unsafe {
-            msg_send![self.0, fragmentArguments]
-        }
-    }
-
-    pub fn vertex_arguments(&self) -> NSArray<MTLArgument> {
-        unsafe {
-            msg_send![self.0, vertexArguments]
-        }
+        this
     }
 }
 
-impl NSObjectProtocol for MTLRenderPipelineReflection {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLRenderPipelineReflectionInternal").unwrap()
+impl RenderPipelineReflectionRef {
+    pub fn fragment_arguments(&self) -> &Array<Argument> {
+        unsafe {
+            msg_send![self, fragmentArguments]
+        }
     }
-}*/
+
+    pub fn vertex_arguments(&self) -> &Array<Argument> {
+        unsafe {
+            msg_send![self, vertexArguments]
+        }
+    }
+}
 
 pub enum MTLRenderPipelineDescriptor {}
 
@@ -250,23 +234,20 @@ foreign_obj_type! {
     pub struct RenderPipelineDescriptor;
     pub struct RenderPipelineDescriptorRef;
 }
-/*
-impl<'a> MTLRenderPipelineDescriptor {
-    pub fn alloc() -> Self {
+
+impl RenderPipelineDescriptor {
+    pub fn new() -> Self {
         unsafe {
-            msg_send![Self::class(), alloc]
+            let class = Class::get("MTLRenderPipelineDescriptor").unwrap();
+            msg_send![class, new]
         }
     }
+}
 
-    pub fn init(&self) -> Self {
+impl RenderPipelineDescriptorRef {
+    pub fn label(&self) -> &str {
         unsafe {
-            msg_send![self.0, init]
-        }
-    }
-
-    pub fn label(&'a self) -> &'a str {
-        unsafe {
-            let label: &'a NSString = msg_send![self.0, label];
+            let label: &NSString = msg_send![self, label];
             label.as_str()
         }
     }
@@ -274,61 +255,61 @@ impl<'a> MTLRenderPipelineDescriptor {
     pub fn set_label(&self, label: &str) {
         unsafe {
             let nslabel = NSString::from_str(label);
-            msg_send![self.0, setLabel:nslabel]
+            msg_send![self, setLabel:nslabel]
         }
     }
 
-    pub fn vertex_function(&self) -> MTLFunction {
+    pub fn vertex_function(&self) -> Option<&FunctionRef> {
         unsafe {
-            msg_send![self.0, vertexFunction]
+            msg_send![self, vertexFunction]
         }
     }
 
-    pub fn set_vertex_function(&self, function: MTLFunction) {
+    pub fn set_vertex_function(&self, function: Option<&FunctionRef>) {
         unsafe {
-            msg_send![self.0, setVertexFunction:function.0]
+            msg_send![self, setVertexFunction:function]
         }
     }
 
-    pub fn fragment_function(&self) -> MTLFunction {
+    pub fn fragment_function(&self) -> Option<&FunctionRef> {
         unsafe {
-            msg_send![self.0, fragmentFunction]
+            msg_send![self, fragmentFunction]
         }
     }
 
-    pub fn set_fragment_function(&self, function: MTLFunction) {
+    pub fn set_fragment_function(&self, function: Option<&FunctionRef>) {
         unsafe {
-            msg_send![self.0, setFragmentFunction:function.0]
+            msg_send![self, setFragmentFunction:function]
         }
     }
 
-    pub fn vertex_descriptor(&self) -> MTLVertexDescriptor {
+    pub fn vertex_descriptor(&self) -> Option<&VertexDescriptorRef> {
         unsafe {
-            msg_send![self.0, vertexDescriptor]
+            msg_send![self, vertexDescriptor]
         }
     }
 
-    pub fn set_vertex_descriptor(&self, descriptor: MTLVertexDescriptor) {
+    pub fn set_vertex_descriptor(&self, descriptor: Option<&VertexDescriptorRef>) {
         unsafe {
-            msg_send![self.0, setVertexDescriptor:descriptor.0]
+            msg_send![self, setVertexDescriptor:descriptor]
         }
     }
 
-    pub fn sample_count(&self) -> u64 {
+    pub fn sample_count(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, sampleCount]
+            msg_send![self, sampleCount]
         }
     }
 
-    pub fn set_sample_count(&self, count: u64) {
+    pub fn set_sample_count(&self, count: NSUInteger) {
         unsafe {
-            msg_send![self.0, setSampleCount:count]
+            msg_send![self, setSampleCount:count]
         }
     }
 
     pub fn is_alpha_to_coverage_enabled(&self) -> bool {
         unsafe {
-            match msg_send![self.0, isAlphaToCoverageEnabled] {
+            match msg_send![self, isAlphaToCoverageEnabled] {
                 YES => true,
                 NO => false,
                 _ => unreachable!()
@@ -338,13 +319,13 @@ impl<'a> MTLRenderPipelineDescriptor {
 
     pub fn set_alpha_to_coverage_enabled(&self, enabled: bool) {
         unsafe {
-            msg_send![self.0, setAlphaToCoverageEnabled:enabled]
+            msg_send![self, setAlphaToCoverageEnabled:enabled]
         }
     }
 
     pub fn is_alpha_to_one_enabled(&self) -> bool {
         unsafe {
-            match msg_send![self.0, isAlphaToOneEnabled] {
+            match msg_send![self, isAlphaToOneEnabled] {
                 YES => true,
                 NO => false,
                 _ => unreachable!()
@@ -354,13 +335,13 @@ impl<'a> MTLRenderPipelineDescriptor {
 
     pub fn set_alpha_to_one_enabled(&self, enabled: bool) {
         unsafe {
-            msg_send![self.0, setAlphaToOneEnabled:enabled]
+            msg_send![self, setAlphaToOneEnabled:enabled]
         }
     }
 
     pub fn is_rasterization_enabled(&self) -> bool {
         unsafe {
-            match msg_send![self.0, isRasterizationEnabled] {
+            match msg_send![self, isRasterizationEnabled] {
                 YES => true,
                 NO => false,
                 _ => unreachable!()
@@ -370,74 +351,64 @@ impl<'a> MTLRenderPipelineDescriptor {
 
     pub fn set_rasterization_enabled(&self, enabled: bool) {
         unsafe {
-            msg_send![self.0, setRasterizationEnabled:enabled]
+            msg_send![self, setRasterizationEnabled:enabled]
         }
     }
 
-    pub fn color_attachments(&self) -> MTLRenderPipelineColorAttachmentDescriptorArray {
+    pub fn color_attachments(&self) -> &RenderPipelineColorAttachmentDescriptorArrayRef {
         unsafe {
-            msg_send![self.0, colorAttachments]
+            msg_send![self, colorAttachments]
         }
     }
 
     pub fn depth_attachment_pixel_format(&self) -> MTLPixelFormat {
         unsafe {
-            msg_send![self.0, depthAttachmentPixelFormat]
+            msg_send![self, depthAttachmentPixelFormat]
         }
     }
 
     pub fn set_depth_attachment_pixel_format(&self, pixel_format: MTLPixelFormat) {
         unsafe {
-            msg_send![self.0, setDepthAttachmentPixelFormat:pixel_format]
+            msg_send![self, setDepthAttachmentPixelFormat:pixel_format]
         }
     }
 
     pub fn stencil_attachment_pixel_format(&self) -> MTLPixelFormat {
         unsafe {
-            msg_send![self.0, stencilAttachmentPixelFormat]
+            msg_send![self, stencilAttachmentPixelFormat]
         }
     }
 
     pub fn set_stencil_attachment_pixel_format(&self, pixel_format: MTLPixelFormat) {
         unsafe {
-            msg_send![self.0, setStencilAttachmentPixelFormat:pixel_format]
+            msg_send![self, setStencilAttachmentPixelFormat:pixel_format]
         }
     }
 
     pub fn input_primitive_topology(&self) -> MTLPrimitiveTopologyClass {
         unsafe {
-            msg_send![self.0, inputPrimitiveTopology]
+            msg_send![self, inputPrimitiveTopology]
         }
     }
 
     pub fn set_input_primitive_topology(&self, topology: MTLPrimitiveTopologyClass) {
         unsafe {
-            msg_send![self.0, setInputPrimitiveTopology:topology]
+            msg_send![self, setInputPrimitiveTopology:topology]
         }
     }
 
-    pub fn serialize_vertex_data(&self) -> *mut libc::c_void {
+    pub unsafe fn serialize_vertex_data(&self) -> *mut libc::c_void {
         use std::ptr;
         let flags = 0;
-        let err: *mut id = ptr::null_mut();
-        unsafe {
-            msg_send![self.0, newSerializedVertexDataWithFlags:flags
-                              error:err]
-        }
+        let err: *mut Object = ptr::null_mut();
+        msg_send![self, newSerializedVertexDataWithFlags:flags
+                                                    error:err]
     }
 
-    pub fn serialize_fragment_data(&self) -> *mut libc::c_void {
-        unsafe {
-            msg_send![self.0, serializeFragmentData]
-        }
+    pub unsafe fn serialize_fragment_data(&self) -> *mut libc::c_void {
+        msg_send![self, serializeFragmentData]
     }
 }
-
-impl NSObjectProtocol for MTLRenderPipelineDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLRenderPipelineDescriptorInternal").unwrap()
-    }
-}*/
 
 pub enum MTLRenderPipelineState {}
 
@@ -446,11 +417,11 @@ foreign_obj_type! {
     pub struct RenderPipelineState;
     pub struct RenderPipelineStateRef;
 }
-/*
-impl<'a> MTLRenderPipelineState {
-    pub fn label(&'a self) -> &'a str {
+
+impl RenderPipelineStateRef {
+    pub fn label(&self) -> &str {
         unsafe {
-            let label: &'a NSString = msg_send![self.0, label];
+            let label: &NSString = msg_send![self, label];
             label.as_str()
         }
     }
@@ -458,16 +429,10 @@ impl<'a> MTLRenderPipelineState {
     pub fn set_label(&self, label: &str) {
         unsafe {
             let nslabel = NSString::from_str(label);
-            msg_send![self.0, setLabel:nslabel]
+            msg_send![self, setLabel:nslabel]
         }
     }
 }
-
-impl NSObjectProtocol for MTLRenderPipelineState {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLRenderPipelineState").unwrap()
-    }
-}*/
 
 pub enum MTLRenderPipelineColorAttachmentDescriptorArray {}
 
@@ -476,25 +441,18 @@ foreign_obj_type! {
     pub struct RenderPipelineColorAttachmentDescriptorArray;
     pub struct RenderPipelineColorAttachmentDescriptorArrayRef;
 }
-/*
-impl MTLRenderPipelineColorAttachmentDescriptorArray {
-    pub fn object_at(&self, index: usize) -> MTLRenderPipelineColorAttachmentDescriptor {
+
+impl RenderPipelineColorAttachmentDescriptorArrayRef {
+    pub fn object_at(&self, index: usize) -> Option<&RenderPipelineColorAttachmentDescriptorRef> {
         unsafe {
-            msg_send![self.0, objectAtIndexedSubscript:index]
+            msg_send![self, objectAtIndexedSubscript:index]
         }
     }
 
-    pub fn set_object_at(&self, index: usize, attachment: MTLRenderPipelineColorAttachmentDescriptor) {
+    pub fn set_object_at(&self, index: usize, attachment: Option<&RenderPipelineColorAttachmentDescriptorRef>) {
         unsafe {
-            msg_send![self.0, setObject:attachment.0
-                     atIndexedSubscript:index]
+            msg_send![self, setObject:attachment
+                   atIndexedSubscript:index]
         }
     }
 }
-
-impl NSObjectProtocol for MTLRenderPipelineColorAttachmentDescriptorArray {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLRenderPipelineColorAttachmentDescriptorArray").unwrap()
-    }
-}*/
-

--- a/src/renderpass.rs
+++ b/src/renderpass.rs
@@ -5,10 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use objc::runtime::Class;
+use super::*;
 
-use texture::MTLTexture;
-use buffer::MTLBuffer;
+use objc::runtime::Class;
+use cocoa::foundation::NSUInteger;
 
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -46,322 +46,294 @@ impl MTLClearColor {
         }
     }
 }
-/*
-pub enum MTLRenderPassAttachmentDescriptorPrototype {}
-pub type MTLRenderPassAttachmentDescriptor = id<(MTLRenderPassAttachmentDescriptorPrototype, (NSObjectPrototype, ()))>;
 
-impl MTLRenderPassAttachmentDescriptor {
-    pub fn texture(&self) -> MTLTexture {
+pub enum MTLRenderPassAttachmentDescriptor {}
+
+foreign_obj_type! {
+    type CType = MTLRenderPassAttachmentDescriptor;
+    pub struct RenderPassAttachmentDescriptor;
+    pub struct RenderPassAttachmentDescriptorRef;
+}
+
+impl RenderPassAttachmentDescriptorRef {
+    pub fn texture(&self) -> Option<&TextureRef> {
         unsafe {
-            msg_send![self.0, texture]
+            msg_send![self, texture]
         }
     }
 
-    pub fn set_texture(&self, texture: MTLTexture) {
+    pub fn set_texture(&self, texture: Option<&TextureRef>) {
         unsafe {
-            msg_send![self.0, setTexture:texture.0]
+            msg_send![self, setTexture:texture];
         }
     }
 
-    pub fn level(&self) -> u64 {
+    pub fn level(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, level]
+            msg_send![self, level]
         }
     }
 
-    pub fn set_level(&self, level: u64) {
+    pub fn set_level(&self, level: NSUInteger) {
         unsafe {
-            msg_send![self.0, setLevel:level]
+            msg_send![self, setLevel:level]
         }
     }
 
-    pub fn slice(&self) -> u64 {
+    pub fn slice(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, slice]
+            msg_send![self, slice]
         }
     }
 
-    pub fn set_slice(&self, slice: u64) {
+    pub fn set_slice(&self, slice: NSUInteger) {
         unsafe {
-            msg_send![self.0, setSlice:slice]
+            msg_send![self, setSlice:slice]
         }
     }
 
-    pub fn depth_plane(&self) -> u64 {
+    pub fn depth_plane(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, depthPlane]
+            msg_send![self, depthPlane]
         }
     }
 
-    pub fn set_depth_plane(&self, depth_plane: u64) {
+    pub fn set_depth_plane(&self, depth_plane: NSUInteger) {
         unsafe {
-            msg_send![self.0, setDepthPlane:depth_plane]
+            msg_send![self, setDepthPlane:depth_plane]
         }
     }
 
-    pub fn resolve_texture(&self) -> MTLTexture {
+    pub fn resolve_texture(&self) -> Option<&TextureRef> {
         unsafe {
-            msg_send![self.0, resolveTexture]
+            msg_send![self, resolveTexture]
         }
     }
 
-    pub fn set_resolve_texture(&self, resolve_texture: MTLTexture) {
+    pub fn set_resolve_texture(&self, resolve_texture: Option<&TextureRef>) {
         unsafe {
-            msg_send![self.0, setResolveTexture:resolve_texture.0]
+            msg_send![self, setResolveTexture:resolve_texture]
         }
     }
 
-    pub fn resolve_level(&self) -> u64 {
+    pub fn resolve_level(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, resolveLevel]
+            msg_send![self, resolveLevel]
         }
     }
 
-    pub fn set_resolve_level(&self, resolve_level: u64) {
+    pub fn set_resolve_level(&self, resolve_level: NSUInteger) {
         unsafe {
-            msg_send![self.0, setResolveLevel:resolve_level]
+            msg_send![self, setResolveLevel:resolve_level]
         }
     }
 
-    pub fn resolve_slice(&self) -> u64 {
+    pub fn resolve_slice(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, resolveSlice]
+            msg_send![self, resolveSlice]
         }
     }
 
-    pub fn set_resolve_slice(&self, resolve_slice: u64) {
+    pub fn set_resolve_slice(&self, resolve_slice: NSUInteger) {
         unsafe {
-            msg_send![self.0, setResolveSlice:resolve_slice]
+            msg_send![self, setResolveSlice:resolve_slice]
         }
     }
 
-    pub fn resolve_depth_plane(&self) -> u64 {
+    pub fn resolve_depth_plane(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, resolveDepthPlane]
+            msg_send![self, resolveDepthPlane]
         }
     }
 
-    pub fn set_resolve_depth_plane(&self, resolve_depth_plane: u64) {
+    pub fn set_resolve_depth_plane(&self, resolve_depth_plane: NSUInteger) {
         unsafe {
-            msg_send![self.0, setResolveDepthPlane:resolve_depth_plane]
+            msg_send![self, setResolveDepthPlane:resolve_depth_plane]
         }
     }
 
     pub fn load_action(&self) -> MTLLoadAction {
         unsafe {
-            msg_send![self.0, loadAction]
+            msg_send![self, loadAction]
         }
     }
 
     pub fn set_load_action(&self, load_action: MTLLoadAction) {
         unsafe {
-            msg_send![self.0, setLoadAction:load_action]
+            msg_send![self, setLoadAction:load_action]
         }
     }
 
     pub fn store_action(&self) -> MTLStoreAction {
         unsafe {
-            msg_send![self.0, storeAction]
+            msg_send![self, storeAction]
         }
     }
 
     pub fn set_store_action(&self, store_action: MTLStoreAction) {
         unsafe {
-            msg_send![self.0, setStoreAction:store_action]
+            msg_send![self, setStoreAction:store_action]
         }
     }
 }
 
-impl NSObjectProtocol for MTLRenderPassAttachmentDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLRenderPassAttachmentDescriptor").unwrap()
+pub enum MTLRenderPassColorAttachmentDescriptor {}
+
+foreign_obj_type! {
+    type CType = MTLRenderPassColorAttachmentDescriptor;
+    pub struct RenderPassColorAttachmentDescriptor;
+    pub struct RenderPassColorAttachmentDescriptorRef;
+    type ParentType = RenderPassAttachmentDescriptorRef;
+}
+
+impl RenderPassColorAttachmentDescriptor {
+    pub fn new() -> Self {
+        unsafe {
+            let class = Class::get("MTLRenderPassColorAttachmentDescriptor").unwrap();
+            msg_send![class, new]
+        }
     }
 }
 
-pub enum MTLRenderPassColorAttachmentDescriptorPrototype {}
-pub type MTLRenderPassColorAttachmentDescriptor = id<
-    (MTLRenderPassColorAttachmentDescriptorPrototype,
-        (MTLRenderPassAttachmentDescriptorPrototype,
-            (NSObjectPrototype, ())))>;
-
-impl MTLRenderPassColorAttachmentDescriptor {
-    pub fn alloc() -> Self {
-        unsafe {
-            msg_send![Self::class(), alloc]
-        }
-    }
-
-    pub fn init(&self) -> Self {
-        unsafe {
-            msg_send![self.0, init]
-        }
-    }
-
+impl RenderPassAttachmentDescriptorRef {
     pub fn clear_color(&self) -> MTLClearColor {
         unsafe {
-            msg_send![self.0, clearColor]
+            msg_send![self, clearColor]
         }
     }
 
     pub fn set_clear_color(&self, clear_color: MTLClearColor) {
         unsafe {
-            msg_send![self.0, setClearColor:clear_color]
+            msg_send![self, setClearColor:clear_color]
         }
     }
 }
 
-impl NSObjectProtocol for MTLRenderPassColorAttachmentDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLRenderPassColorAttachmentDescriptor").unwrap()
-    }
+pub enum MTLRenderPassDepthAttachmentDescriptor {}
+
+foreign_obj_type! {
+    type CType = MTLRenderPassDepthAttachmentDescriptor;
+    pub struct RenderPassDepthAttachmentDescriptor;
+    pub struct RenderPassDepthAttachmentDescriptorRef;
+    type ParentType = RenderPassAttachmentDescriptorRef;
 }
 
-pub enum MTLRenderPassDepthAttachmentDescriptorPrototype {}
-pub type MTLRenderPassDepthAttachmentDescriptor = id<
-    (MTLRenderPassDepthAttachmentDescriptorPrototype,
-        (MTLRenderPassAttachmentDescriptorPrototype,
-            (NSObjectPrototype, ())))>;
-
-impl MTLRenderPassDepthAttachmentDescriptor {
+impl RenderPassDepthAttachmentDescriptorRef {
     pub fn clear_depth(&self) -> f64 {
         unsafe {
-            msg_send![self.0, clearDepth]
+            msg_send![self, clearDepth]
         }
     }
 
     pub fn set_clear_depth(&self, clear_depth: f64) {
         unsafe {
-            msg_send![self.0, setClearDepth:clear_depth]
+            msg_send![self, setClearDepth:clear_depth]
         }
     }
 }
 
-impl NSObjectProtocol for MTLRenderPassDepthAttachmentDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLRenderPassDepthAttachmentDescriptor").unwrap()
-    }
+pub enum MTLRenderPassStencilAttachmentDescriptor {}
+
+foreign_obj_type! {
+    type CType = MTLRenderPassStencilAttachmentDescriptor;
+    pub struct RenderPassStencilAttachmentDescriptor;
+    pub struct RenderPassStencilAttachmentDescriptorRef;
 }
 
-pub enum MTLRenderPassStencilAttachmentDescriptorPrototype {}
-pub type MTLRenderPassStencilAttachmentDescriptor = id<
-    (MTLRenderPassStencilAttachmentDescriptorPrototype,
-        (MTLRenderPassAttachmentDescriptorPrototype,
-            (NSObjectPrototype, ())))>;
-
-impl MTLRenderPassStencilAttachmentDescriptor {
+impl RenderPassStencilAttachmentDescriptorRef {
     pub fn clear_stencil(&self) -> u32 {
         unsafe {
-            msg_send![self.0, clearStencil]
+            msg_send![self, clearStencil]
         }
     }
 
     pub fn set_clear_stencil(&self, clear_stencil: u32) {
         unsafe {
-            msg_send![self.0, setClearStencil:clear_stencil]
+            msg_send![self, setClearStencil:clear_stencil]
         }
     }
 }
 
-impl NSObjectProtocol for MTLRenderPassStencilAttachmentDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLRenderPassStencilAttachmentDescriptor").unwrap()
-    }
+pub enum MTLRenderPassColorAttachmentDescriptorArray {}
+
+foreign_obj_type! {
+    type CType = MTLRenderPassColorAttachmentDescriptorArray;
+    pub struct RenderPassColorAttachmentDescriptorArray;
+    pub struct RenderPassColorAttachmentDescriptorArrayRef;
 }
 
-
-
-pub enum MTLRenderPassColorAttachmentDescriptorArrayPrototype {}
-pub type MTLRenderPassColorAttachmentDescriptorArray = id<(MTLRenderPassColorAttachmentDescriptorArrayPrototype, (NSObjectPrototype, ()))>;
-
-impl MTLRenderPassColorAttachmentDescriptorArray {
-    pub fn object_at(&self, index: usize) -> MTLRenderPassColorAttachmentDescriptor {
+impl RenderPassColorAttachmentDescriptorArrayRef {
+    pub fn object_at(&self, index: usize) -> Option<&RenderPassColorAttachmentDescriptorRef> {
         unsafe {
-            msg_send![self.0, objectAtIndexedSubscript:index]
+            msg_send![self, objectAtIndexedSubscript:index]
         }
     }
 
-    pub fn set_object_at(&self, index: usize, attachment: MTLRenderPassColorAttachmentDescriptor) {
+    pub fn set_object_at(&self, index: usize, attachment: Option<&RenderPassColorAttachmentDescriptorRef>) {
         unsafe {
-            msg_send![self.0, setObject:attachment.0
+            msg_send![self, setObject:attachment
                      atIndexedSubscript:index]
         }
     }
 }
 
-impl NSObjectProtocol for MTLRenderPassColorAttachmentDescriptorArray {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLRenderPassColorAttachmentDescriptorArray").unwrap()
-    }
+pub enum MTLRenderPassDescriptor {}
+
+foreign_obj_type! {
+    type CType = MTLRenderPassDescriptor;
+    pub struct RenderPassDescriptor;
+    pub struct RenderPassDescriptorRef;
 }
 
-pub enum MTLRenderPassDescriptorPrototype {}
-pub type MTLRenderPassDescriptor = id<(MTLRenderPassDescriptorPrototype, (NSObjectPrototype, ()))>;
-
-impl MTLRenderPassDescriptor {
-    pub fn new() -> Self {
+impl RenderPassDescriptor {
+    pub fn new<'a>() -> &'a RenderPassDescriptorRef {
         unsafe {
-            msg_send![Self::class(), renderPassDescriptor]
-        }
-    }
-
-    pub fn alloc() -> Self {
-        unsafe {
-            msg_send![Self::class(), alloc]
-        }
-    }
-
-    pub fn init(&self) -> Self {
-        unsafe {
-            msg_send![self.0, init]
-        }
-    }
-
-    pub fn color_attachments(&self) -> MTLRenderPassColorAttachmentDescriptorArray {
-        unsafe {
-            msg_send![self.0, colorAttachments]
-        }
-    }
-
-    pub fn depth_attachment(&self) -> MTLRenderPassDepthAttachmentDescriptor {
-        unsafe {
-            msg_send![self.0, depthAttachment]
-        }
-    }
-
-    pub fn set_depth_attachment(&self, depth_attachment: MTLRenderPassDepthAttachmentDescriptor) {
-        unsafe {
-            msg_send![self.0, setDepthAttachment:depth_attachment.0]
-        }
-    }
-
-    pub fn stencil_attachment(&self) -> MTLRenderPassStencilAttachmentDescriptor {
-        unsafe {
-            msg_send![self.0, stencilAttachment]
-        }
-    }
-
-    pub fn set_stencil_attachment(&self, stencil_attachment: MTLRenderPassStencilAttachmentDescriptor) {
-        unsafe {
-            msg_send![self.0, setStencilAttachment:stencil_attachment.0]
-        }
-    }
-
-    pub fn visibility_result_buffer(&self) -> MTLBuffer {
-        unsafe {
-            msg_send![self.0, visibilityResultBuffer]
-        }
-    }
-
-    pub fn render_target_array_length(&self) -> u64 {
-        unsafe {
-            msg_send![self.0, renderTargetArrayLength]
+            let class = Class::get("MTLRenderPassDescriptorInternal").unwrap();
+            msg_send![class, renderPassDescriptor]
         }
     }
 }
 
-impl NSObjectProtocol for MTLRenderPassDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLRenderPassDescriptorInternal").unwrap()
+impl RenderPassDescriptorRef {
+    pub fn color_attachments(&self) -> &RenderPassColorAttachmentDescriptorArrayRef {
+        unsafe {
+            msg_send![self, colorAttachments]
+        }
     }
-}*/
 
+    pub fn depth_attachment(&self) -> Option<&RenderPassDepthAttachmentDescriptorRef> {
+        unsafe {
+            msg_send![self, depthAttachment]
+        }
+    }
+
+    pub fn set_depth_attachment(&self, depth_attachment: Option<&RenderPassDepthAttachmentDescriptorRef>) {
+        unsafe {
+            msg_send![self, setDepthAttachment:depth_attachment]
+        }
+    }
+
+    pub fn stencil_attachment(&self) -> Option<&RenderPassStencilAttachmentDescriptorRef> {
+        unsafe {
+            msg_send![self, stencilAttachment]
+        }
+    }
+
+    pub fn set_stencil_attachment(&self, stencil_attachment: Option<&RenderPassStencilAttachmentDescriptorRef>) {
+        unsafe {
+            msg_send![self, setStencilAttachment:stencil_attachment]
+        }
+    }
+
+    pub fn visibility_result_buffer(&self) -> Option<&BufferRef> {
+        unsafe {
+            msg_send![self, visibilityResultBuffer]
+        }
+    }
+
+    pub fn render_target_array_length(&self) -> NSUInteger {
+        unsafe {
+            msg_send![self, renderTargetArrayLength]
+        }
+    }
+}

--- a/src/renderpass.rs
+++ b/src/renderpass.rs
@@ -7,8 +7,6 @@
 
 use objc::runtime::Class;
 
-use super::{id, NSObjectPrototype, NSObjectProtocol};
-
 use texture::MTLTexture;
 use buffer::MTLBuffer;
 
@@ -48,7 +46,7 @@ impl MTLClearColor {
         }
     }
 }
-
+/*
 pub enum MTLRenderPassAttachmentDescriptorPrototype {}
 pub type MTLRenderPassAttachmentDescriptor = id<(MTLRenderPassAttachmentDescriptorPrototype, (NSObjectPrototype, ()))>;
 
@@ -365,5 +363,5 @@ impl NSObjectProtocol for MTLRenderPassDescriptor {
     unsafe fn class() -> &'static Class {
         Class::get("MTLRenderPassDescriptorInternal").unwrap()
     }
-}
+}*/
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use cocoa::foundation::NSUInteger;
-use objc::runtime::Class;
 use objc_foundation::{NSString, INSString};
 
 #[repr(u64)]
@@ -72,11 +71,10 @@ foreign_obj_type! {
     pub struct ResourceRef;
 }
 
-/*
-impl<'a> MTLResource {
-    pub fn label(&'a self) -> &'a str {
+impl ResourceRef {
+    pub fn label(&self) -> &str {
         unsafe {
-            let label: &'a NSString = msg_send![self.0, label];
+            let label: &NSString = msg_send![self, label];
             label.as_str()
         }
     }
@@ -84,32 +82,25 @@ impl<'a> MTLResource {
     pub fn set_label(&self, label: &str) {
         unsafe {
             let nslabel = NSString::from_str(label);
-            msg_send![self.0, setLabel:nslabel]
+            msg_send![self, setLabel:nslabel]
         }
     }
 
     pub fn cpu_cache_mode(&self) -> MTLCPUCacheMode {
         unsafe {
-            msg_send![self.0, cpuCacheMode]
+            msg_send![self, cpuCacheMode]
         }
     }
 
     pub fn storage_mode(&self) -> MTLStorageMode {
         unsafe {
-            msg_send![self.0, storageMode]
+            msg_send![self, storageMode]
         }
     }
 
     pub fn set_purgeable_state(&self, state: MTLPurgeableState) -> MTLPurgeableState {
         unsafe {
-            msg_send![self.0, setPurgeableState:state]
+            msg_send![self, setPurgeableState:state]
         }
     }
 }
-
-impl NSObjectProtocol for MTLResource {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLResource").unwrap()
-    }
-}*/
-

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -9,8 +9,6 @@ use cocoa::foundation::NSUInteger;
 use objc::runtime::Class;
 use objc_foundation::{NSString, INSString};
 
-use super::{id, NSObjectPrototype, NSObjectProtocol};
-
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -66,10 +64,15 @@ pub struct MTLSizeAndAlign {
     pub align: NSUInteger,
 }
 
+pub enum MTLResource {}
 
-pub enum MTLResourcePrototype {}
-pub type MTLResource = id<(MTLResourcePrototype, (NSObjectPrototype, ()))>;
+foreign_obj_type! {
+    type CType = MTLResource;
+    pub struct Resource;
+    pub struct ResourceRef;
+}
 
+/*
 impl<'a> MTLResource {
     pub fn label(&'a self) -> &'a str {
         unsafe {
@@ -108,5 +111,5 @@ impl NSObjectProtocol for MTLResource {
     unsafe fn class() -> &'static Class {
         Class::get("MTLResource").unwrap()
     }
-}
+}*/
 

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -7,8 +7,6 @@
 
 use objc::runtime::Class;
 
-use super::{id, NSObjectPrototype, NSObjectProtocol};
-
 use depthstencil::MTLCompareFunction;
 
 #[repr(u64)]
@@ -36,9 +34,15 @@ pub enum MTLSamplerAddressMode {
     ClampToZero = 4,
 }
 
-pub enum MTLSamplerDescriptorPrototype {}
-pub type MTLSamplerDescriptor = id<(MTLSamplerDescriptorPrototype, (NSObjectPrototype, ()))>;
+pub enum MTLSamplerDescriptor {}
 
+foreign_obj_type! {
+    type CType = MTLSamplerDescriptor;
+    pub struct SamplerDescriptor;
+    pub struct SamplerDescriptorRef;
+}
+
+/*
 impl MTLSamplerDescriptor {
     pub fn new() -> Self {
         unsafe {
@@ -129,13 +133,19 @@ impl NSObjectProtocol for MTLSamplerDescriptor {
     unsafe fn class() -> &'static Class {
         Class::get("MTLSamplerDescriptor").unwrap()
     }
+}*/
+
+pub enum MTLSamplerState {}
+
+foreign_obj_type! {
+    type CType = MTLSamplerState;
+    pub struct SamplerState;
+    pub struct SamplerStateRef;
 }
 
-pub enum MTLSamplerStatePrototype {}
-pub type MTLSamplerState = id<(MTLSamplerStatePrototype, (NSObjectPrototype, ()))>;
-
+/*
 impl NSObjectProtocol for MTLSamplerState {
     unsafe fn class() -> &'static Class {
         Class::get("MTLSamplerState").unwrap()
     }
-}
+}*/

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use objc::runtime::Class;
+use cocoa::foundation::NSUInteger;
 
 use depthstencil::MTLCompareFunction;
 
@@ -42,98 +43,83 @@ foreign_obj_type! {
     pub struct SamplerDescriptorRef;
 }
 
-/*
-impl MTLSamplerDescriptor {
+
+impl SamplerDescriptor {
     pub fn new() -> Self {
         unsafe {
-            msg_send![Self::class(), new]
+            let class = Class::get("MTLSamplerDescriptor").unwrap();
+            msg_send![class, new]
         }
     }
+}
 
-    pub fn alloc() -> Self {
-        unsafe {
-            msg_send![Self::class(), alloc]
-        }
-    }
-
-    pub fn init(&self) -> Self {
-        unsafe {
-            msg_send![self, init]
-        }
-    }
-
+impl SamplerDescriptorRef {
     pub fn set_min_filter(&self, filter: MTLSamplerMinMagFilter) {
         unsafe {
-            msg_send![self.0, setMinFilter:filter]
+            msg_send![self, setMinFilter:filter]
         }
     }
 
     pub fn set_mag_filter(&self, filter: MTLSamplerMinMagFilter) {
         unsafe {
-            msg_send![self.0, setMagFilter:filter]
+            msg_send![self, setMagFilter:filter]
         }
     }
 
     pub fn set_mip_filter(&self, filter: MTLSamplerMipFilter) {
         unsafe {
-            msg_send![self.0, setMipFilter:filter]
+            msg_send![self, setMipFilter:filter]
         }
     }
 
     pub fn set_address_mode_s(&self, mode: MTLSamplerAddressMode) {
         unsafe {
-            msg_send![self.0, setSAddressMode:mode]
+            msg_send![self, setSAddressMode:mode]
         }
     }
 
     pub fn set_address_mode_t(&self, mode: MTLSamplerAddressMode) {
         unsafe {
-            msg_send![self.0, setTAddressMode:mode]
+            msg_send![self, setTAddressMode:mode]
         }
     }
 
     pub fn set_address_mode_r(&self, mode: MTLSamplerAddressMode) {
         unsafe {
-            msg_send![self.0, setRAddressMode:mode]
+            msg_send![self, setRAddressMode:mode]
         }
     }
 
-    pub fn set_max_anisotropy(&self, anisotropy: u64) {
+    pub fn set_max_anisotropy(&self, anisotropy: NSUInteger) {
         unsafe {
-            msg_send![self.0, setMaxAnisotropy:anisotropy]
+            msg_send![self, setMaxAnisotropy:anisotropy]
         }
     }
 
     pub fn set_compare_function(&self, func: MTLCompareFunction) {
         unsafe {
-            msg_send![self.0, setCompareFunction:func]
+            msg_send![self, setCompareFunction:func]
         }
     }
 
     pub fn set_lod_bias(&self, bias: f32) {
         unsafe {
-            msg_send![self.0, setLodBias:bias]
+            msg_send![self, setLodBias:bias]
         }
     }
 
     pub fn set_lod_min_clamp(&self, clamp: f32) {
         unsafe {
-            msg_send![self.0, setLodMinClamp:clamp]
+            msg_send![self, setLodMinClamp:clamp]
         }
     }
 
     pub fn set_lod_max_clamp(&self, clamp: f32) {
         unsafe {
-            msg_send![self.0, setLodMaxClamp:clamp]
+            msg_send![self, setLodMaxClamp:clamp]
         }
     }
 }
-
-impl NSObjectProtocol for MTLSamplerDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLSamplerDescriptor").unwrap()
-    }
-}*/
 
 pub enum MTLSamplerState {}
 
@@ -142,10 +128,3 @@ foreign_obj_type! {
     pub struct SamplerState;
     pub struct SamplerStateRef;
 }
-
-/*
-impl NSObjectProtocol for MTLSamplerState {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLSamplerState").unwrap()
-    }
-}*/

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -5,13 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use super::*;
+
 use cocoa::foundation::{NSUInteger, NSRange};
 use objc::runtime::{Class, YES, NO};
-
-use constants::MTLPixelFormat;
-use types::{MTLRegion};
-use buffer::MTLBuffer;
-use resource::{MTLResource,  MTLResourceOptions, MTLCPUCacheMode, MTLStorageMode};
 
 use libc;
 
@@ -48,178 +45,160 @@ foreign_obj_type! {
     pub struct TextureDescriptorRef;
 }
 
-
-
-/*
-impl MTLTextureDescriptor {
+impl TextureDescriptor {
     pub fn new() -> Self {
         unsafe {
-            msg_send![Self::class(), new]
+            let class = Class::get("MTLTextureDescriptor").unwrap();
+            msg_send![class, new]
         }
     }
+}
 
-    pub fn alloc() -> Self {
-        unsafe {
-            msg_send![Self::class(), alloc]
-        }
-    }
-
-    pub fn init(&self) -> Self {
-        unsafe {
-            msg_send![self.0, init]
-        }
-    }
-
+impl TextureDescriptorRef {
     pub fn texture_type(&self) -> MTLTextureType {
         unsafe {
-            msg_send![self.0, textureType]
+            msg_send![self, textureType]
         }
     }
 
     pub fn set_texture_type(&self, texture_type: MTLTextureType) {
         unsafe {
-            msg_send![self.0, setTextureType:texture_type]
+            msg_send![self, setTextureType:texture_type]
         }
     }
 
     pub fn pixel_format(&self) -> MTLPixelFormat {
         unsafe {
-            msg_send![self.0, pixelFormat]
+            msg_send![self, pixelFormat]
         }
     }
 
     pub fn set_pixel_format(&self, pixel_format: MTLPixelFormat) {
         unsafe {
-            msg_send![self.0, setPixelFormat:pixel_format]
+            msg_send![self, setPixelFormat:pixel_format]
         }
     }
 
-    pub fn width(&self) -> u64 {
+    pub fn width(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, width]
+            msg_send![self, width]
         }
     }
 
-    pub fn set_width(&self, width: u64) {
+    pub fn set_width(&self, width: NSUInteger) {
         unsafe {
-            msg_send![self.0, setWidth:width]
+            msg_send![self, setWidth:width]
         }
     }
 
-    pub fn height(&self) -> u64 {
+    pub fn height(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, height]
+            msg_send![self, height]
         }
     }
 
-    pub fn set_height(&self, height: u64) {
+    pub fn set_height(&self, height: NSUInteger) {
         unsafe {
-            msg_send![self.0, setHeight:height]
+            msg_send![self, setHeight:height]
         }
     }
 
-    pub fn depth(&self) -> u64 {
+    pub fn depth(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, depth]
+            msg_send![self, depth]
         }
     }
 
-    pub fn set_depth(&self, depth: u64) {
+    pub fn set_depth(&self, depth: NSUInteger) {
         unsafe {
-            msg_send![self.0, setDepth:depth]
+            msg_send![self, setDepth:depth]
         }
     }
 
-    pub fn mipmap_level_count(&self) -> u64 {
+    pub fn mipmap_level_count(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, mipmapLevelCount]
+            msg_send![self, mipmapLevelCount]
         }
     }
 
-    pub fn set_mipmap_level_count(&self, count: u64) {
+    pub fn set_mipmap_level_count(&self, count: NSUInteger) {
         unsafe {
-            msg_send![self.0, setMipmapLevelCount:count]
+            msg_send![self, setMipmapLevelCount:count]
         }
     }
 
-    pub fn sample_count(&self) -> u64 {
+    pub fn sample_count(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, sampleCount]
+            msg_send![self, sampleCount]
         }
     }
 
-    pub fn set_sample_count(&self, count: u64) {
+    pub fn set_sample_count(&self, count: NSUInteger) {
         unsafe {
-            msg_send![self.0, setSampleCount:count]
+            msg_send![self, setSampleCount:count]
         }
     }
 
-    pub fn array_length(&self) -> u64 {
+    pub fn array_length(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, arrayLength]
+            msg_send![self, arrayLength]
         }
     }
 
-    pub fn set_array_length(&self, length: u64) {
+    pub fn set_array_length(&self, length: NSUInteger) {
         unsafe {
-            msg_send![self.0, setArrayLength:length]
+            msg_send![self, setArrayLength:length]
         }
     }
 
     pub fn resource_options(&self) -> MTLResourceOptions {
         unsafe {
-            msg_send![self.0, resourceOptions]
+            msg_send![self, resourceOptions]
         }
     }
 
     pub fn set_resource_options(&self, options: MTLResourceOptions) {
         unsafe {
-            msg_send![self.0, setResourceOptions:options]
+            msg_send![self, setResourceOptions:options]
         }
     }
 
     pub fn cpu_cache_mode(&self) -> MTLCPUCacheMode {
         unsafe {
-            msg_send![self.0, cpuCacheMode]
+            msg_send![self, cpuCacheMode]
         }
     }
 
     pub fn set_cpu_cache_mode(&self, mode: MTLCPUCacheMode) {
         unsafe {
-            msg_send![self.0, setCpuCacheMode:mode]
+            msg_send![self, setCpuCacheMode:mode]
         }
     }
 
     pub fn storage_mode(&self) -> MTLStorageMode {
         unsafe {
-            msg_send![self.0, storageMode]
+            msg_send![self, storageMode]
         }
     }
 
     pub fn set_storage_mode(&self, mode: MTLStorageMode) {
         unsafe {
-            msg_send![self.0, setStorageMode:mode]
+            msg_send![self, setStorageMode:mode]
         }
     }
 
     pub fn usage(&self) -> MTLTextureUsage {
         unsafe {
-            msg_send![self.0, usage]
+            msg_send![self, usage]
         }
     }
 
     pub fn set_usage(&self, usage: MTLTextureUsage) {
         unsafe {
-            msg_send![self.0, setUsage:usage]
+            msg_send![self, setUsage:usage]
         }
     }
 }
-
-impl NSObjectProtocol for MTLTextureDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLTextureDescriptor").unwrap()
-    }
-}*/
 
 pub enum MTLTexture {}
 
@@ -227,126 +206,109 @@ foreign_obj_type! {
     type CType = MTLTexture;
     pub struct Texture;
     pub struct TextureRef;
+    type ParentType = ResourceRef;
 }
 
-
-
-/*
-impl<'a> MTLTexture {
-    pub fn root_resource(&self) -> Option<MTLResource> {
+impl TextureRef {
+    pub fn root_resource(&self) -> Option<&ResourceRef> {
        unsafe {
-           let resource: MTLResource = msg_send![self.0, rootResource];
-
-           match resource.is_null() {
-               true => None,
-               false => Some(resource)
-           }
+           msg_send![self, rootResource]
        }
     }
 
-    pub fn parent_texture(&self) -> Option<MTLTexture> {
-       unsafe {
-           let texture: MTLTexture = msg_send![self.0, parentTexture];
-
-           match texture.is_null() {
-               true => None,
-               false => Some(texture)
-           }
-       }
-    }
-
-    pub fn parent_relative_level(&self) -> u64 {
+    pub fn parent_texture(&self) -> Option<&TextureRef> {
         unsafe {
-            msg_send![self.0, parentRelativeLevel]
+            msg_send![self, parentTexture]
         }
     }
 
-    pub fn parent_relative_slice(&self) -> u64 {
+    pub fn parent_relative_level(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, parentRelativeSlice]
+            msg_send![self, parentRelativeLevel]
         }
     }
 
-    pub fn buffer(&self) -> Option<MTLBuffer> {
+    pub fn parent_relative_slice(&self) -> NSUInteger {
         unsafe {
-            let buf: MTLBuffer = msg_send![self.0, buffer];
-
-            match buf.is_null() {
-                true => None,
-                false => Some(buf)
-            }
+            msg_send![self, parentRelativeSlice]
         }
     }
 
-    pub fn buffer_offset(&self) -> u64 {
+    pub fn buffer(&self) -> Option<&BufferRef> {
         unsafe {
-            msg_send![self.0, bufferOffset]
+            msg_send![self, buffer]
         }
     }
 
-    pub fn buffer_stride(&self) -> u64 {
+    pub fn buffer_offset(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, bufferBytesPerRow]
+            msg_send![self, bufferOffset]
+        }
+    }
+
+    pub fn buffer_stride(&self) -> NSUInteger {
+        unsafe {
+            msg_send![self, bufferBytesPerRow]
         }
     }
 
     pub fn texture_type(&self) -> MTLTextureType {
         unsafe {
-            msg_send![self.0, textureType]
+            msg_send![self, textureType]
         }
     }
 
     pub fn pixel_format(&self) -> MTLPixelFormat {
         unsafe {
-            msg_send![self.0, pixelFormat]
+            msg_send![self, pixelFormat]
         }
     }
 
-    pub fn width(&self) -> u64 {
+    pub fn width(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, width]
+            msg_send![self, width]
         }
     }
 
-    pub fn height(&self) -> u64 {
+    pub fn height(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, height]
+            msg_send![self, height]
         }
     }
 
-    pub fn depth(&self) -> u64 {
+    pub fn depth(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, depth]
+            msg_send![self, depth]
         }
     }
 
-    pub fn mipmap_level_count(&self) -> u64 {
+    pub fn mipmap_level_count(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, mipmapLevelCount]
+            msg_send![self, mipmapLevelCount]
         }
     }
 
-    pub fn sample_count(&self) -> u64 {
+    pub fn sample_count(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, sampleCount]
+            msg_send![self, sampleCount]
         }
     }
 
-    pub fn array_length(&self) -> u64 {
+    pub fn array_length(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, arrayLength]
+            msg_send![self, arrayLength]
         }
     }
 
     pub fn usage(&self) -> MTLTextureUsage {
         unsafe {
-            msg_send![self.0, usage]
+            msg_send![self, usage]
         }
     }
 
     pub fn framebuffer_only(&self) -> bool {
         unsafe {
-            match msg_send![self.0, framebufferOnly] {
+            match msg_send![self, framebufferOnly] {
                 YES => true,
                 NO => false,
                 _ => unreachable!()
@@ -354,18 +316,18 @@ impl<'a> MTLTexture {
         }
     }
 
-    pub fn get_bytes(&self, bytes: *mut libc::c_void, region: MTLRegion, mipmap_level: u64, stride: u64) {
+    pub fn get_bytes(&self, bytes: *mut libc::c_void, region: MTLRegion, mipmap_level: NSUInteger, stride: NSUInteger) {
         unsafe {
-            msg_send![self.0, getBytes:bytes
+            msg_send![self, getBytes:bytes
                          bytesPerRow:stride
                           fromRegion:region
                          mipmapLevel:mipmap_level]
         }
     }
 
-    pub fn get_bytes_in_slice(&self, bytes: *mut libc::c_void, region: MTLRegion, mipmap_level: u64, stride: u64, image_stride: u64, slice: u64) {
+    pub fn get_bytes_in_slice(&self, bytes: *mut libc::c_void, region: MTLRegion, mipmap_level: NSUInteger, stride: NSUInteger, image_stride: NSUInteger, slice: NSUInteger) {
         unsafe {
-            msg_send![self.0, getBytes:bytes
+            msg_send![self, getBytes:bytes
                          bytesPerRow:stride
                        bytesPerImage:image_stride
                           fromRegion:region
@@ -374,18 +336,18 @@ impl<'a> MTLTexture {
         }
     }
 
-    pub fn replace_region(&self, region: MTLRegion, mipmap_level: u64, stride: u64, bytes: *const libc::c_void) {
+    pub fn replace_region(&self, region: MTLRegion, mipmap_level: NSUInteger, stride: NSUInteger, bytes: *const libc::c_void) {
         unsafe {
-            msg_send![self.0, replaceRegion:region
+            msg_send![self, replaceRegion:region
                               mipmapLevel:mipmap_level
                                 withBytes:bytes
                               bytesPerRow:stride]
         }
     }
 
-    pub fn replace_region_in_slice(&self, region: MTLRegion, mipmap_level: u64, image_stride: u64, stride: u64, slice: u64, bytes: *const libc::c_void) {
+    pub fn replace_region_in_slice(&self, region: MTLRegion, mipmap_level: NSUInteger, image_stride: NSUInteger, stride: NSUInteger, slice: NSUInteger, bytes: *const libc::c_void) {
         unsafe {
-            msg_send![self.0, replaceRegion:region
+            msg_send![self, replaceRegion:region
                               mipmapLevel:mipmap_level
                                     slice:slice
                                 withBytes:bytes
@@ -394,25 +356,18 @@ impl<'a> MTLTexture {
         }
     }
 
-    pub fn new_texture_view(&self, pixel_format: MTLPixelFormat) -> MTLTexture {
+    pub fn new_texture_view(&self, pixel_format: MTLPixelFormat) -> Texture {
         unsafe {
-            msg_send![self.0, newTextureViewWithPixelFormat:pixel_format]
+            msg_send![self, newTextureViewWithPixelFormat:pixel_format]
         }
     }
 
-    pub fn new_texture_view_from_slice(&self, pixel_format: MTLPixelFormat, texture_type: MTLTextureType, mipmap_levels: NSRange, slices: NSRange) -> MTLTexture {
+    pub fn new_texture_view_from_slice(&self, pixel_format: MTLPixelFormat, texture_type: MTLTextureType, mipmap_levels: NSRange, slices: NSRange) -> Texture {
         unsafe {
-            msg_send![self.0, newTextureViewWithPixelFormat:pixel_format
+            msg_send![self, newTextureViewWithPixelFormat:pixel_format
                                                 textureType:texture_type
                                                      levels:mipmap_levels
                                                      slices:slices]
         }
     }
 }
-
-impl NSObjectProtocol for MTLTexture {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLTexture").unwrap()
-    }
-}*/
-

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -8,12 +8,10 @@
 use cocoa::foundation::{NSUInteger, NSRange};
 use objc::runtime::{Class, YES, NO};
 
-use super::{id, NSObjectPrototype, NSObjectProtocol};
-
 use constants::MTLPixelFormat;
 use types::{MTLRegion};
 use buffer::MTLBuffer;
-use resource::{MTLResource, MTLResourcePrototype, MTLResourceOptions, MTLCPUCacheMode, MTLStorageMode};
+use resource::{MTLResource,  MTLResourceOptions, MTLCPUCacheMode, MTLStorageMode};
 
 use libc;
 
@@ -42,10 +40,17 @@ bitflags! {
     }
 }
 
+pub enum MTLTextureDescriptor {}
 
-pub enum MTLTextureDescriptorPrototype {}
-pub type MTLTextureDescriptor = id<(MTLTextureDescriptorPrototype, (NSObjectPrototype, ()))>;
+foreign_obj_type! {
+    type CType = MTLTextureDescriptor;
+    pub struct TextureDescriptor;
+    pub struct TextureDescriptorRef;
+}
 
+
+
+/*
 impl MTLTextureDescriptor {
     pub fn new() -> Self {
         unsafe {
@@ -214,11 +219,19 @@ impl NSObjectProtocol for MTLTextureDescriptor {
     unsafe fn class() -> &'static Class {
         Class::get("MTLTextureDescriptor").unwrap()
     }
+}*/
+
+pub enum MTLTexture {}
+
+foreign_obj_type! {
+    type CType = MTLTexture;
+    pub struct Texture;
+    pub struct TextureRef;
 }
 
-pub enum MTLTexturePrototype {}
-pub type MTLTexture = id<(MTLTexturePrototype, (MTLResourcePrototype, (NSObjectPrototype, ())))>;
 
+
+/*
 impl<'a> MTLTexture {
     pub fn root_resource(&self) -> Option<MTLResource> {
        unsafe {
@@ -401,5 +414,5 @@ impl NSObjectProtocol for MTLTexture {
     unsafe fn class() -> &'static Class {
         Class::get("MTLTexture").unwrap()
     }
-}
+}*/
 

--- a/src/vertexdescriptor.rs
+++ b/src/vertexdescriptor.rs
@@ -7,8 +7,6 @@
 
 use objc::runtime::Class;
 
-use super::{id, NSObjectPrototype, NSObjectProtocol};
-
 use libc;
 
 #[repr(u64)]
@@ -64,7 +62,7 @@ pub enum MTLVertexStepFunction {
     PerVertex = 1,
     PerInstance = 2,
 }
-
+/*
 pub enum MTLVertexBufferLayoutDescriptorPrototype {}
 pub type MTLVertexBufferLayoutDescriptor = id<(MTLVertexBufferLayoutDescriptorPrototype, (NSObjectPrototype, ()))>;
 
@@ -225,11 +223,16 @@ impl NSObjectProtocol for MTLVertexAttributeDescriptorArray {
     unsafe fn class() -> &'static Class {
         Class::get("MTLVertexAttributeDescriptorArray").unwrap()
     }
+}*/
+
+pub enum MTLVertexDescriptor {}
+
+foreign_obj_type! {
+    type CType = MTLVertexDescriptor;
+    pub struct VertexDescriptor;
+    pub struct VertexDescriptorRef;
 }
-
-pub enum MTLVertexDescriptorPrototype {}
-pub type MTLVertexDescriptor = id<(MTLVertexDescriptorPrototype, (NSObjectPrototype, ()))>;
-
+/*
 impl MTLVertexDescriptor {
     pub fn new() -> Self {
         unsafe {
@@ -266,5 +269,5 @@ impl NSObjectProtocol for MTLVertexDescriptor {
     unsafe fn class() -> &'static Class {
         Class::get("MTLVertexDescriptor").unwrap()
     }
-}
+}*/
 

--- a/src/vertexdescriptor.rs
+++ b/src/vertexdescriptor.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use objc::runtime::Class;
+use cocoa::foundation::NSUInteger;
 
 use libc;
 
@@ -62,168 +63,162 @@ pub enum MTLVertexStepFunction {
     PerVertex = 1,
     PerInstance = 2,
 }
-/*
-pub enum MTLVertexBufferLayoutDescriptorPrototype {}
-pub type MTLVertexBufferLayoutDescriptor = id<(MTLVertexBufferLayoutDescriptorPrototype, (NSObjectPrototype, ()))>;
 
-impl MTLVertexBufferLayoutDescriptor {
-    pub fn alloc() -> Self {
+pub enum MTLVertexBufferLayoutDescriptor {}
+
+foreign_obj_type! {
+    type CType = MTLVertexBufferLayoutDescriptor;
+    pub struct VertexBufferLayoutDescriptor;
+    pub struct VertexBufferLayoutDescriptorRef;
+}
+
+impl VertexBufferLayoutDescriptor {
+    pub fn new () -> Self {
         unsafe {
-            msg_send![Self::class(), alloc]
+            let class = Class::get("MTLVertexBufferLayoutDescriptor").unwrap();
+            msg_send![class, new]
+        }
+    }
+}
+
+impl VertexBufferLayoutDescriptorRef {
+    pub fn stride(&self) -> NSUInteger {
+        unsafe {
+            msg_send![self, stride]
         }
     }
 
-    pub fn init(&self) -> Self {
+    pub fn set_stride(&self, stride: NSUInteger) {
         unsafe {
-            msg_send![self.0, init]
-        }
-    }
-
-    pub fn stride(&self) -> u64 {
-        unsafe {
-            msg_send![self.0, stride]
-        }
-    }
-
-    pub fn set_stride(&self, stride: u64) {
-        unsafe {
-            msg_send![self.0, setStride:stride]
+            msg_send![self, setStride:stride]
         }
     }
 
     pub fn step_function(&self) -> MTLVertexStepFunction {
         unsafe {
-            msg_send![self.0, stepFunction]
+            msg_send![self, stepFunction]
         }
     }
 
     pub fn set_step_function(&self, func: MTLVertexStepFunction) {
         unsafe {
-            msg_send![self.0, setStepFunction:func]
+            msg_send![self, setStepFunction:func]
         }
     }
 
-    pub fn step_rate(&self) -> u64 {
+    pub fn step_rate(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, stepRate]
+            msg_send![self, stepRate]
         }
     }
 
-    pub fn set_step_rate(&self, step_rate: u64) {
+    pub fn set_step_rate(&self, step_rate: NSUInteger) {
         unsafe {
-            msg_send![self.0, setStepRate:step_rate]
+            msg_send![self, setStepRate:step_rate]
         }
     }
 }
 
-impl NSObjectProtocol for MTLVertexBufferLayoutDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLVertexBufferLayoutDescriptor").unwrap()
-    }
+pub enum MTLVertexBufferLayoutDescriptorArray {}
+
+foreign_obj_type! {
+    type CType = MTLVertexBufferLayoutDescriptorArray;
+    pub struct VertexBufferLayoutDescriptorArray;
+    pub struct VertexBufferLayoutDescriptorArrayRef;
 }
 
-
-pub enum MTLVertexBufferLayoutDescriptorArrayPrototype {}
-pub type MTLVertexBufferLayoutDescriptorArray = id<(MTLVertexBufferLayoutDescriptorArrayPrototype, (NSObjectPrototype, ()))>;
-
-impl MTLVertexBufferLayoutDescriptorArray {
-    pub fn object_at(&self, index: usize) -> MTLVertexBufferLayoutDescriptor {
+impl VertexBufferLayoutDescriptorArrayRef {
+    pub fn object_at(&self, index: usize) -> Option<&VertexBufferLayoutDescriptorRef> {
         unsafe {
-            msg_send![self.0, objectAtIndexedSubscript:index]
+            msg_send![self, objectAtIndexedSubscript:index]
         }
     }
 
-    pub fn set_object_at(&self, index: usize, layout: MTLVertexBufferLayoutDescriptor) {
+    pub fn set_object_at(&self, index: usize, layout: Option<&VertexBufferLayoutDescriptorRef>) {
         unsafe {
-            msg_send![self.0, setObject:layout.0
-                     atIndexedSubscript:index]
+            msg_send![self, setObject:layout
+                   atIndexedSubscript:index]
         }
     }
 }
 
-impl NSObjectProtocol for MTLVertexBufferLayoutDescriptorArray {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLVertexBufferLayoutDescriptorArray").unwrap()
+pub enum MTLVertexAttributeDescriptor {}
+
+foreign_obj_type! {
+    type CType = MTLVertexAttributeDescriptor;
+    pub struct VertexAttributeDescriptor;
+    pub struct VertexAttributeDescriptorRef;
+}
+
+impl VertexAttributeDescriptor {
+    pub fn new() -> Self {
+        unsafe {
+            let class = Class::get("MTLVertexAttributeDescriptor").unwrap();
+            msg_send![class, new]
+        }
     }
 }
 
-
-pub enum MTLVertexAttributeDescriptorPrototype {}
-pub type MTLVertexAttributeDescriptor = id<(MTLVertexAttributeDescriptorPrototype, (NSObjectPrototype, ()))>;
-
-impl MTLVertexAttributeDescriptor {
-    pub fn alloc() -> Self {
-        unsafe {
-            msg_send![Self::class(), alloc]
-        }
-    }
-
+impl VertexAttributeDescriptorRef {
     pub fn format(&self) -> MTLVertexFormat {
         unsafe {
-            msg_send![self.0, format]
+            msg_send![self, format]
         }
     }
 
     pub fn set_format(&self, format: MTLVertexFormat) {
         unsafe {
-            msg_send![self.0, setFormat:format]
+            msg_send![self, setFormat:format]
         }
     }
 
-    pub fn offset(&self) -> u64 {
+    pub fn offset(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, offset]
+            msg_send![self, offset]
         }
     }
 
-    pub fn set_offset(&self, offset: u64) {
+    pub fn set_offset(&self, offset: NSUInteger) {
         unsafe {
-            msg_send![self.0, setOffset:offset]
+            msg_send![self, setOffset:offset]
         }
     }
 
-    pub fn buffer_index(&self) -> u64 {
+    pub fn buffer_index(&self) -> NSUInteger {
         unsafe {
-            msg_send![self.0, bufferIndex]
+            msg_send![self, bufferIndex]
         }
     }
 
-    pub fn set_buffer_index(&self, index: u64) {
+    pub fn set_buffer_index(&self, index: NSUInteger) {
         unsafe {
-            msg_send![self.0, setBufferIndex:index]
+            msg_send![self, setBufferIndex:index]
         }
     }
 }
 
-impl NSObjectProtocol for MTLVertexAttributeDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLVertexAttributeDescriptor").unwrap()
-    }
-}
+pub enum MTLVertexAttributeDescriptorArray {}
 
-pub enum MTLVertexAttributeDescriptorArrayPrototype {}
-pub type MTLVertexAttributeDescriptorArray = id<(MTLVertexAttributeDescriptorArrayPrototype, (NSObjectPrototype, ()))>;
+foreign_obj_type! {
+    type CType = MTLVertexAttributeDescriptorArray;
+    pub struct VertexAttributeDescriptorArray;
+    pub struct VertexAttributeDescriptorArrayRef;
+}
 
 impl MTLVertexAttributeDescriptorArray {
-    pub fn object_at(&self, index: usize) -> MTLVertexAttributeDescriptor {
+    pub fn object_at(&self, index: usize) -> Option<&VertexAttributeDescriptorRef> {
         unsafe {
-            msg_send![self.0, objectAtIndexedSubscript:index]
+            msg_send![self, objectAtIndexedSubscript:index]
         }
     }
 
-    pub fn set_object_at(&self, index: usize, attribute: MTLVertexAttributeDescriptor) {
+    pub fn set_object_at(&self, index: usize, attribute: Option<&VertexAttributeDescriptorRef>) {
         unsafe {
-            msg_send![self.0, setObject:attribute
-                     atIndexedSubscript:index]
+            msg_send![self, setObject:attribute
+                   atIndexedSubscript:index]
         }
     }
 }
-
-impl NSObjectProtocol for MTLVertexAttributeDescriptorArray {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLVertexAttributeDescriptorArray").unwrap()
-    }
-}*/
 
 pub enum MTLVertexDescriptor {}
 
@@ -232,42 +227,36 @@ foreign_obj_type! {
     pub struct VertexDescriptor;
     pub struct VertexDescriptorRef;
 }
-/*
-impl MTLVertexDescriptor {
-    pub fn new() -> Self {
-        unsafe {
-            msg_send![Self::class(), vertexDescriptor]
-        }
-    }
 
-    pub fn layouts(&self) -> MTLVertexBufferLayoutDescriptorArray {
+impl VertexDescriptor {
+    pub fn new<'a>() -> &'a VertexDescriptorRef {
         unsafe {
-            msg_send![self.0, layouts]
-        }
-    }
-
-    pub fn attributes(&self) -> MTLVertexAttributeDescriptorArray {
-        unsafe {
-            msg_send![self.0, attributes]
-        }
-    }
-
-    pub fn serialize_descriptor(&self) -> *mut libc::c_void {
-        unsafe {
-            msg_send![self.0, newSerializedDescriptor]
-        }
-    }
-
-    pub fn reset(&self) {
-        unsafe {
-            msg_send![self.0, reset]
+            let class = Class::get("MTLVertexDescriptor").unwrap();
+            msg_send![class, vertexDescriptor]
         }
     }
 }
 
-impl NSObjectProtocol for MTLVertexDescriptor {
-    unsafe fn class() -> &'static Class {
-        Class::get("MTLVertexDescriptor").unwrap()
+impl VertexDescriptorRef {
+    pub fn layouts(&self) -> &VertexBufferLayoutDescriptorArrayRef {
+        unsafe {
+            msg_send![self, layouts]
+        }
     }
-}*/
 
+    pub fn attributes(&self) -> &VertexAttributeDescriptorArrayRef {
+        unsafe {
+            msg_send![self, attributes]
+        }
+    }
+
+    pub unsafe fn serialize_descriptor(&self) -> *mut libc::c_void {
+        msg_send![self, newSerializedDescriptor]
+    }
+
+    pub fn reset(&self) {
+        unsafe {
+            msg_send![self, reset]
+        }
+    }
+}


### PR DESCRIPTION
This is very WIP, I just wanted to make sure this is the direction we want to go before I do the rest of the changes. The one file that is pretty much finished is `device.rs`.

As it stands `metal-rs` mostly leaves it to the user to determine lifetimes and remember to release objects. To rectify this we can use the [foreign-types](https://docs.rs/foreign-types/0.3.0/foreign_types/index.html) crate, which creates a `str`/`String`-type dichotomy for arbitrary C types. 

So far I'm following the convention that other ObjC crates like [core-graphics](https://github.com/servo/core-graphics-rs) do and using the naming convention `*mut MTLFoo` for the raw opaque pointer, `Foo` for the owned pointer, and `&FooRef` for the unowned pointer. Incoming arguments are always `&FooRef`, and return values are either `&FooRef` or `Foo` depending on the API's choices.

This isn't 100% safe because all Metal objects are potentially shared references, and there's the potential for nasty interactions with autorelease pools, but this at least gives us decent defaults.