### PR TITLE
Add function constants

### DIFF
--- a/examples/reflection/main.rs
+++ b/examples/reflection/main.rs
@@ -52,7 +52,7 @@ fn main() {
 
     let options = CompileOptions::new();
     let library = device.new_library_with_source(PROGRAM, &options).unwrap();
-    let (vs, ps) = (library.get_function("vs").unwrap(), library.get_function("ps").unwrap());
+    let (vs, ps) = (library.get_function("vs", None).unwrap(), library.get_function("ps", None).unwrap());
 
     let vertex_desc = VertexDescriptor::new();
 

--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -27,8 +27,8 @@ use std::mem;
 
 
 fn prepare_pipeline_state<'a>(device: &DeviceRef, library: &LibraryRef) -> RenderPipelineState {
-    let vert = library.get_function("triangle_vertex").unwrap();
-    let frag = library.get_function("triangle_fragment").unwrap();
+    let vert = library.get_function("triangle_vertex", None).unwrap();
+    let frag = library.get_function("triangle_fragment", None).unwrap();
 
     let pipeline_state_descriptor = RenderPipelineDescriptor::new();
     pipeline_state_descriptor.set_vertex_function(Some(&vert));


### PR DESCRIPTION
Add initial support for `MTLFunctionConstantValues` to use in gfx specialization constants.

Please take a look and let me know if this seems right. I'm not sure how the deallocations are supposed to work, but I've tried to follow the other examples.

Note this changes the signature of `get_function`. I can introduce a separate function instead if that's preferable.