### PR TITLE
Add `Device::new_library_with_data` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metal-rs"
-version = "0.6.1"
+version = "0.6.2"
 description = "Rust bindings for Metal"
 documentation = "https://docs.rs/crate/metal-rs"
 homepage = "https://github.com/gfx-rs/metal-rs"
@@ -53,3 +53,7 @@ path = "examples/argument-buffer/main.rs"
 [[example]]
 name = "compute"
 path = "examples/compute/main.rs"
+
+[[example]]
+name = "embedded-lib"
+path = "examples/compute/embedded-lib.rs"

--- a/examples/compute/embedded-lib.rs
+++ b/examples/compute/embedded-lib.rs
@@ -1,0 +1,32 @@
+// Copyright 2017 GFX developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+extern crate metal_rs as metal;
+extern crate cocoa;
+#[macro_use] extern crate objc;
+
+use metal::*;
+
+use cocoa::foundation::NSAutoreleasePool;
+
+fn main() {
+    let library_data = include_bytes!("default.metallib");
+
+    let pool = unsafe { NSAutoreleasePool::new(cocoa::base::nil) };
+    let device = Device::system_default();
+
+    let library = device.new_library_with_data(&library_data[..]).unwrap();
+    let kernel = library.get_function("sum", None).unwrap();
+
+    println!("Function name: {}", kernel.name());
+    println!("Function type: {:?}", kernel.function_type());
+    println!("OK");
+
+    unsafe {
+        msg_send![pool, release]
+    }
+}

--- a/src/library.rs
+++ b/src/library.rs
@@ -55,6 +55,7 @@ impl VertexAttributeRef {
 
 #[repr(u64)]
 #[allow(non_camel_case_types)]
+#[derive(Debug)]
 pub enum MTLFunctionType {
     Vertex = 1,
     Fragment = 2,


### PR DESCRIPTION
This method comes handy when you want to embed metallib in your code during build process, as shown in the `embedded-lib` example.