### PR TITLE
Add device registryID

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -132,6 +132,12 @@ impl DeviceRef {
         }
     }
 
+    pub fn registry_id(&self) -> u64 {
+        unsafe {
+            msg_send![self, registryID]
+        }
+    }
+
     pub fn max_threads_per_threadgroup(&self) -> MTLSize {
         unsafe {
             msg_send![self, maxThreadsPerThreadgroup]


### PR DESCRIPTION
I don't have access to a MacOS device right now, but this should compile and run fine. If you would like to wait a couple days I might be able to get access to an Apple device to test this on. More documentation found here https://developer.apple.com/documentation/metal/mtldevice/2915737-registryid