### PR TITLE
Add functions from gfx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metal-rs"
-version = "0.8.0"
+version = "0.8.1"
 description = "Rust bindings for Metal"
 documentation = "https://docs.rs/crate/metal-rs"
 homepage = "https://github.com/gfx-rs/metal-rs"

--- a/src/capturemanager.rs
+++ b/src/capturemanager.rs
@@ -72,6 +72,10 @@ impl CaptureManagerRef {
         unsafe { msg_send![self, defaultCaptureScope] }
     }
 
+    pub fn set_default_capture_scope(&self, scope: &CaptureScopeRef) {
+        unsafe { msg_send![self, setDefaultCaptureScope:scope] }
+    }
+
     pub fn start_capture_with_device(&self, device: &DeviceRef) {
         unsafe {
             msg_send![self, startCaptureWithDevice: device];

--- a/src/commandqueue.rs
+++ b/src/commandqueue.rs
@@ -43,4 +43,10 @@ impl CommandQueueRef {
             msg_send![self, commandBufferWithUnretainedReferences]
         }
     }
+
+    pub fn device(&self) -> &DeviceRef {
+        unsafe {
+            msg_send![self, device]
+        }
+    }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -353,6 +353,16 @@ impl RenderCommandEncoderRef {
         }
     }
 
+    pub fn draw_primitives_instanced_base_instance(&self, primitive_type: MTLPrimitiveType, vertex_start: NSUInteger, vertex_count: NSUInteger, instance_count: NSUInteger, base_instance: NSUInteger) {
+        unsafe {
+            msg_send![self, drawPrimitives:primitive_type
+                               vertexStart:vertex_start
+                               vertexCount:vertex_count
+                             instanceCount:instance_count
+                              baseInstance:base_instance]
+        }
+    }
+
     pub fn draw_indexed_primitives(&self, primitive_type: MTLPrimitiveType, index_count: NSUInteger, index_type: MTLIndexType, index_buffer: &BufferRef, index_buffer_offset: NSUInteger) {
         unsafe {
             msg_send![self, drawIndexedPrimitives:primitive_type
@@ -414,6 +424,45 @@ impl BlitCommandEncoderRef {
         }
     }
 
+    pub fn copy_from_buffer(&self, source_buffer: &BufferRef, source_offset: NSUInteger, destination_buffer: &BufferRef, destination_offset: NSUInteger, size: NSUInteger) {
+        unsafe {
+            msg_send![self, copyFromBuffer:source_buffer
+                              sourceOffset:source_offset
+                                  toBuffer:destination_buffer
+                         destinationOffset:destination_offset
+                                      size:size]
+        }
+    }
+
+    pub fn copy_from_buffer_to_texture(&self, source_buffer: &BufferRef, source_offset: NSUInteger, source_bytes_per_row: NSUInteger, source_bytes_per_image: NSUInteger, source_size: MTLSize, destination_texture: &TextureRef, destination_slice: NSUInteger, destination_level: NSUInteger, destination_origin: MTLOrigin) {
+        unsafe {
+            msg_send![self, copyFromBuffer:source_buffer
+                              sourceOffset:source_offset
+                         sourceBytesPerRow:source_bytes_per_row
+                       sourceBytesPerImage:source_bytes_per_image
+                                sourceSize:source_size
+                                 toTexture:destination_texture
+                          destinationSlice:destination_slice
+                          destinationLevel:destination_level
+                         destinationOrigin:destination_origin
+            ]
+        }
+    }
+
+    pub fn copy_from_texture_to_buffer(&self, source_texture: &TextureRef, source_slice: NSUInteger, source_level: NSUInteger, source_origin: MTLOrigin, source_size: MTLSize, destination_buffer: &BufferRef, destination_offset: NSUInteger, destination_bytes_per_row: NSUInteger, destination_bytes_per_image: NSUInteger) {
+        unsafe {
+            msg_send![self, copyFromTexture:source_texture
+                                sourceSlice:source_slice
+                                sourceLevel:source_level
+                               sourceOrigin:source_origin
+                                 sourceSize:source_size
+                                   toBuffer:destination_buffer
+                          destinationOffset:destination_offset
+                     destinationBytesPerRow:destination_bytes_per_row
+                   destinationBytesPerImage:destination_bytes_per_image
+            ]
+        }
+    }
 }
 
 pub enum MTLComputeCommandEncoder {}

--- a/src/library.rs
+++ b/src/library.rs
@@ -95,6 +95,12 @@ impl FunctionRef {
             ArgumentEncoder::from_ptr(ptr)
         }
     }
+
+    pub fn function_constants_dictionary(&self) -> *mut Object {
+        unsafe {
+            msg_send![self, functionConstantsDictionary]
+        }
+    }
 }
 
 #[repr(u64)]

--- a/src/renderpass.rs
+++ b/src/renderpass.rs
@@ -336,4 +336,10 @@ impl RenderPassDescriptorRef {
             msg_send![self, renderTargetArrayLength]
         }
     }
+
+    pub fn set_render_target_array_length(&self, length: NSUInteger) {
+        unsafe {
+            msg_send![self, setRenderTargetArrayLength:length]
+        }
+    }
 }


### PR DESCRIPTION
Moved some functions from gfx (for gfx-rs/gfx#1972)

This isn't comprehensive yet – I've just moved the functions that were mostly straightforward. The remaining cases probably need more discussion (i.e. what to do with `ConcreteBlock` and `IOSurface` dependencies).