### PR TITLE
Remove set_buffers on compute pipeline descriptor

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -7,7 +7,7 @@
 
 #[repr(u64)]
 #[allow(non_camel_case_types)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum MTLPixelFormat {
    Invalid                = 0,
    A8Unorm                = 1,

--- a/src/pipeline/compute.rs
+++ b/src/pipeline/compute.rs
@@ -176,12 +176,6 @@ impl ComputePipelineDescriptorRef {
         }
     }
 
-    pub fn set_buffers(&self, buffers: Option<&PipelineBufferDescriptorArrayRef>) {
-        unsafe {
-            msg_send![self, setBuffers:buffers]
-        }
-    }
-
     pub fn reset(&self) {
         unsafe {
             msg_send![self, reset]

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -14,7 +14,7 @@ use libc;
 
 #[repr(u64)]
 #[allow(non_camel_case_types)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum MTLTextureType {
     D1 = 0,
     D1Array = 1,


### PR DESCRIPTION
Metal docs indicate this property to be read-only. (breaking change?..)