### PR TITLE
Fix the zombie error of shader compilation

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -229,8 +229,8 @@ impl DeviceRef {
                 let desc: *mut Object = msg_send![err, localizedDescription];
                 let compile_error: *const libc::c_char = msg_send![desc, UTF8String];
                 let message = CStr::from_ptr(compile_error).to_string_lossy().into_owned();
-                msg_send![err, release];
                 if library.is_null() {
+                    msg_send![err, release];
                     return Err(message);
                 } else {
                     warn!("Shader warnings: {}", message);


### PR DESCRIPTION
What I think is happening is that the library object keeps a reference to the error, so we shouldn't release it if the library is created.