### PR TITLE
Cache class access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ block = "0.1.5"
 foreign-types = "0.3"
 
 [dependencies.objc]
-version = "0.2.1"
+version = "0.2.3"
 features = ["objc_exception"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metal-rs"
-version = "0.10.2"
+version = "0.10.3"
 description = "Rust bindings for Metal"
 documentation = "https://docs.rs/crate/metal-rs"
 homepage = "https://github.com/gfx-rs/metal-rs"

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -8,7 +8,7 @@
 use ::{Array, MTLTextureType};
 
 use cocoa::foundation::NSUInteger;
-use objc::runtime::{Class, YES, NO};
+use objc::runtime::{YES, NO};
 use objc_foundation::{NSString, INSString};
 
 #[repr(u64)]
@@ -320,7 +320,7 @@ foreign_obj_type! {
 impl ArgumentDescriptor {
     pub fn new<'a>() -> &'a ArgumentDescriptorRef {
         unsafe {
-            let class = Class::get("MTLArgumentDescriptor").unwrap();
+            let class = class!(MTLArgumentDescriptor);
             msg_send![class, argumentDescriptor]
         }
     }

--- a/src/capturemanager.rs
+++ b/src/capturemanager.rs
@@ -7,7 +7,6 @@
 
 use super::*;
 
-use objc::runtime::Class;
 use objc_foundation::{INSString, NSString};
 
 pub enum MTLCaptureScope {}
@@ -50,7 +49,7 @@ foreign_obj_type! {
 impl CaptureManager {
     pub fn shared<'a>() -> &'a CaptureManagerRef {
         unsafe {
-            let class = Class::get("MTLCaptureManager").unwrap();
+            let class = class!(MTLCaptureManager);
             msg_send![class, sharedCaptureManager]
         }
     }

--- a/src/depthstencil.rs
+++ b/src/depthstencil.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use objc::runtime::{Class, YES, NO};
+use objc::runtime::{YES, NO};
 
 #[repr(u64)]
 pub enum MTLCompareFunction {
@@ -42,7 +42,7 @@ foreign_obj_type! {
 impl StencilDescriptor {
     pub fn new() -> Self {
         unsafe {
-            let class = Class::get("MTLStencilDescriptor").unwrap();
+            let class = class!(MTLStencilDescriptor);
             msg_send![class, new]
         }
     }
@@ -134,7 +134,7 @@ foreign_obj_type! {
 impl DepthStencilDescriptor {
     pub fn new() -> Self {
         unsafe {
-            let class = Class::get("MTLDepthStencilDescriptor").unwrap();
+            let class = class!(MTLDepthStencilDescriptor);
             msg_send![class, new]
         }
     }

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -8,7 +8,6 @@
 use super::*;
 
 use cocoa::foundation::NSUInteger;
-use objc::runtime::Class;
 
 pub enum MTLHeap {}
 
@@ -90,7 +89,7 @@ foreign_obj_type! {
 impl HeapDescriptor {
     pub fn new() -> Self {
         unsafe {
-            let class = Class::get("MTLHeapDescriptor").unwrap();
+            let class = class!(MTLHeapDescriptor);
             msg_send![class, new]
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::borrow::{Borrow, ToOwned};
 
-use objc::runtime::{Object, Class, YES, NO};
+use objc::runtime::{Object, YES, NO};
 use cocoa::foundation::NSSize;
 use foreign_types::ForeignType;
 
@@ -159,14 +159,14 @@ impl<T> Array<T> where
  {
     pub fn from_slice(s: &[&T::Ref]) -> Self {
         unsafe {
-            let class = Class::get("NSArray").unwrap();
+            let class = class!(NSArray);
             msg_send![class, arrayWithObjects: s.as_ptr() count: s.len()]
         }
     }
     
     pub fn from_owned_slice(s: &[T]) -> Self {
         unsafe {
-            let class = Class::get("NSArray").unwrap();
+            let class = class!(NSArray);
             msg_send![class, arrayWithObjects: s.as_ptr() count: s.len()]
         }
     }
@@ -254,7 +254,7 @@ foreign_obj_type! {
 impl CoreAnimationLayer {
     pub fn new() -> Self {
         unsafe {
-            let class = Class::get("CAMetalLayer").unwrap();
+            let class = class!(CAMetalLayer);
             msg_send![class, new]
         }
     }

--- a/src/library.rs
+++ b/src/library.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-use objc::runtime::{Class, Object, YES, NO};
+use objc::runtime::{Object, YES, NO};
 use objc_foundation::{NSString, INSString, NSArray};
 use cocoa::foundation::{NSUInteger};
 use foreign_types::ForeignType;
@@ -123,7 +123,7 @@ foreign_obj_type! {
 impl FunctionConstantValues {
     pub fn new() -> Self {
         unsafe {
-            let class = Class::get("MTLFunctionConstantValues").unwrap();
+            let class = class!(MTLFunctionConstantValues);
             msg_send![class, new]
         }
     }
@@ -146,7 +146,7 @@ foreign_obj_type! {
 impl CompileOptions {
     pub fn new() -> Self {
         unsafe {
-            let class = Class::get("MTLCompileOptions").unwrap();
+            let class = class!(MTLCompileOptions);
             msg_send![class, new]
         }
     }

--- a/src/pipeline/compute.rs
+++ b/src/pipeline/compute.rs
@@ -8,7 +8,7 @@
 use super::*;
 
 use cocoa::foundation::NSUInteger;
-use objc::runtime::{Class, YES, NO};
+use objc::runtime::{YES, NO};
 use objc_foundation::{INSString, NSString};
 
 #[repr(u64)]
@@ -109,7 +109,7 @@ foreign_obj_type! {
 impl ComputePipelineDescriptor {
     pub fn new() -> Self {
         unsafe {
-            let class = Class::get("MTLComputePipelineDescriptor").unwrap();
+            let class = class!(MTLComputePipelineDescriptor);
             msg_send![class, new]
         }
     }
@@ -280,7 +280,7 @@ foreign_obj_type! {
 impl StageInputOutputDescriptor {
     pub fn new<'a>() -> &'a StageInputOutputDescriptorRef {
         unsafe {
-            let class = Class::get("MTLStageInputOutputDescriptor").unwrap();
+            let class = class!(MTLStageInputOutputDescriptor);
             msg_send![class, stageInputOutputDescriptor]
         }
     }

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -8,7 +8,7 @@
 use super::*;
 
 use cocoa::foundation::NSUInteger;
-use objc::runtime::{Class, Object, YES, NO};
+use objc::runtime::{Object, YES, NO};
 use objc_foundation::{INSString, NSString};
 
 use libc;
@@ -203,7 +203,7 @@ impl RenderPipelineReflection {
             fragment_data: *mut libc::c_void, vertex_desc: *mut libc::c_void,
             device: &DeviceRef, options: u64, flags: u64) -> Self
     {
-        let class = Class::get("MTLRenderPipelineReflection").unwrap();
+        let class = class!(MTLRenderPipelineReflection);
         let this: RenderPipelineReflection = msg_send![class, alloc];
         let this_alias: *mut Object = msg_send![this.as_ref(), initWithVertexData:vertex_data
                                                                 fragmentData:fragment_data
@@ -243,7 +243,7 @@ foreign_obj_type! {
 impl RenderPipelineDescriptor {
     pub fn new() -> Self {
         unsafe {
-            let class = Class::get("MTLRenderPipelineDescriptor").unwrap();
+            let class = class!(MTLRenderPipelineDescriptor);
             msg_send![class, new]
         }
     }

--- a/src/renderpass.rs
+++ b/src/renderpass.rs
@@ -7,7 +7,6 @@
 
 use super::*;
 
-use objc::runtime::Class;
 use cocoa::foundation::NSUInteger;
 
 #[repr(u64)]
@@ -189,7 +188,7 @@ foreign_obj_type! {
 impl RenderPassColorAttachmentDescriptor {
     pub fn new() -> Self {
         unsafe {
-            let class = Class::get("MTLRenderPassColorAttachmentDescriptor").unwrap();
+            let class = class!(MTLRenderPassColorAttachmentDescriptor);
             msg_send![class, new]
         }
     }
@@ -289,7 +288,7 @@ foreign_obj_type! {
 impl RenderPassDescriptor {
     pub fn new<'a>() -> &'a RenderPassDescriptorRef {
         unsafe {
-            let class = Class::get("MTLRenderPassDescriptorInternal").unwrap();
+            let class = class!(MTLRenderPassDescriptorInternal);
             msg_send![class, renderPassDescriptor]
         }
     }

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -5,7 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use objc::runtime::Class;
 use cocoa::foundation::NSUInteger;
 
 use depthstencil::MTLCompareFunction;
@@ -56,7 +55,7 @@ foreign_obj_type! {
 impl SamplerDescriptor {
     pub fn new() -> Self {
         unsafe {
-            let class = Class::get("MTLSamplerDescriptor").unwrap();
+            let class = class!(MTLSamplerDescriptor);
             msg_send![class, new]
         }
     }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -8,7 +8,7 @@
 use super::*;
 
 use cocoa::foundation::{NSUInteger, NSRange};
-use objc::runtime::{Class, YES, NO};
+use objc::runtime::{YES, NO};
 
 use libc;
 
@@ -47,7 +47,7 @@ foreign_obj_type! {
 impl TextureDescriptor {
     pub fn new() -> Self {
         unsafe {
-            let class = Class::get("MTLTextureDescriptor").unwrap();
+            let class = class!(MTLTextureDescriptor);
             msg_send![class, new]
         }
     }

--- a/src/vertexdescriptor.rs
+++ b/src/vertexdescriptor.rs
@@ -5,7 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use objc::runtime::Class;
 use cocoa::foundation::NSUInteger;
 
 use libc;
@@ -86,7 +85,7 @@ foreign_obj_type! {
 impl VertexBufferLayoutDescriptor {
     pub fn new () -> Self {
         unsafe {
-            let class = Class::get("MTLVertexBufferLayoutDescriptor").unwrap();
+            let class = class!(MTLVertexBufferLayoutDescriptor);
             msg_send![class, new]
         }
     }
@@ -164,7 +163,7 @@ foreign_obj_type! {
 impl VertexAttributeDescriptor {
     pub fn new() -> Self {
         unsafe {
-            let class = Class::get("MTLVertexAttributeDescriptor").unwrap();
+            let class = class!(MTLVertexAttributeDescriptor);
             msg_send![class, new]
         }
     }
@@ -242,7 +241,7 @@ foreign_obj_type! {
 impl VertexDescriptor {
     pub fn new<'a>() -> &'a VertexDescriptorRef {
         unsafe {
-            let class = Class::get("MTLVertexDescriptor").unwrap();
+            let class = class!(MTLVertexDescriptor);
             msg_send![class, vertexDescriptor]
         }
     }


### PR DESCRIPTION
- Uses [objc's new `class` macro](https://github.com/SSheldon/rust-objc/issues/65) to cache all class accesses
- Bumps the crate version to 0.10.3