### PR TITLE
fix iOS: use CGSize instead of NSSize. this is the correct type anyway

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ default-target = "x86_64-apple-darwin"
 
 [dependencies]
 cocoa = "0.17"
+core-graphics = "0.17.0"
 bitflags = "1"
 libc = "0.2"
 log = "0.4"

--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate cocoa;
+extern crate core_graphics;
 extern crate metal;
 extern crate winit;
 #[macro_use] extern crate objc;
@@ -14,8 +15,9 @@ extern crate block;
 extern crate sema;
 
 use cocoa::base::id as cocoa_id;
-use cocoa::foundation::{NSRange, NSSize, NSAutoreleasePool};
+use cocoa::foundation::{NSRange, NSAutoreleasePool};
 use cocoa::appkit::{NSWindow, NSView};
+use core_graphics::geometry::CGSize;
 
 use objc::runtime::YES;
 
@@ -72,7 +74,7 @@ fn main() {
     }
 
     let draw_size = glutin_window.get_inner_size().unwrap();
-    layer.set_drawable_size(NSSize::new(draw_size.width as f64, draw_size.height as f64));
+    layer.set_drawable_size(CGSize::new(draw_size.width as f64, draw_size.height as f64));
 
     let library = device.new_library_with_file("examples/window/default.metallib").unwrap();
     let pipeline_state = prepare_pipeline_state(&device, &library);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![allow(non_upper_case_globals)]
 
 extern crate cocoa;
+extern crate core_graphics;
 #[macro_use]
 extern crate bitflags;
 extern crate libc;
@@ -28,13 +29,9 @@ use std::ops::Deref;
 use std::borrow::{Borrow, ToOwned};
 
 use objc::runtime::{Object, YES, NO};
-use cocoa::foundation::NSSize;
+pub use core_graphics::base::CGFloat;
+pub use core_graphics::geometry::CGSize;
 use foreign_types::ForeignType;
-
-#[cfg(target_pointer_width = "64")]
-pub type CGFloat = libc::c_double;
-#[cfg(not(target_pointer_width = "64"))]
-pub type CGFloat = libc::c_float;
 
 macro_rules! foreign_obj_type {
     {type CType = $raw_ident:ident;
@@ -279,13 +276,13 @@ impl CoreAnimationLayerRef {
         }
     }
 
-    pub fn drawable_size(&self) -> NSSize {
+    pub fn drawable_size(&self) -> CGSize {
         unsafe {
             msg_send![self, drawableSize]
         }
     }
 
-    pub fn set_drawable_size(&self, size: NSSize) {
+    pub fn set_drawable_size(&self, size: CGSize) {
         unsafe {
             msg_send![self, setDrawableSize:size]
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@ use std::ops::Deref;
 use std::borrow::{Borrow, ToOwned};
 
 use objc::runtime::{Object, YES, NO};
-pub use core_graphics::base::CGFloat;
-pub use core_graphics::geometry::CGSize;
+use core_graphics::base::CGFloat;
+use core_graphics::geometry::CGSize;
 use foreign_types::ForeignType;
 
 macro_rules! foreign_obj_type {


### PR DESCRIPTION
This is based on the work in this PR #60 by @Michael-Lfx which has not yet been accepted. I am guessing it's abandoned? If not feel free to reject this.

I, too, want this feature merged to help get `metal` (and ultimately `gfx`) building on iOS.