### PR TITLE
[ios] MTLCopyAllDevices is not supported on iOS

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1333,12 +1333,16 @@ impl Device {
     }
 
     pub fn all() -> Vec<Device> {
-        unsafe {
-            let array = MTLCopyAllDevices();
-            let count: NSUInteger = msg_send![array, count];
-            (0 .. count)
-                .map(|i| msg_send![array, objectAtIndex: i])
-                .collect()
+        if cfg!(target_os = "ios") {
+            vec![Device::system_default()]
+        } else {
+            unsafe {
+                let array = MTLCopyAllDevices();
+                let count: NSUInteger = msg_send![array, count];
+                (0 .. count)
+                    .map(|i| msg_send![array, objectAtIndex: i])
+                    .collect()
+            }
         }
     }
 }


### PR DESCRIPTION
On iOS, `Device::all()` now returns `vec![Device::system_default()]`