### PR TITLE
[iOS] audit msg_send! for ios/tvos compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metal"
-version = "0.12.1"
+version = "0.13.0"
 description = "Rust bindings for Metal"
 documentation = "https://docs.rs/crate/metal"
 homepage = "https://github.com/gfx-rs/metal-rs"
@@ -12,6 +12,10 @@ license = "MIT OR Apache-2.0"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
+
+[features]
+default = []
+private = []
 
 [dependencies]
 cocoa = "0.18"

--- a/examples/caps/main.rs
+++ b/examples/caps/main.rs
@@ -12,11 +12,17 @@ use metal::*;
 fn main() {
     let device = Device::system_default();
 
-    println!("Vendor: {:?}", device.vendor());
-    println!("Family: {:?}", device.family_name());
+    #[cfg(feature = "private")]
+    {
+        println!("Vendor: {:?}", unsafe { device.vendor() });
+        println!("Family: {:?}", unsafe { device.family_name() });
+    }
     println!("Max threads per threadgroup: {:?}", device.max_threads_per_threadgroup());
-    println!("Integrated GPU: {:?}", device.is_low_power());
-    println!("Headless: {:?}", device.is_headless());
-    println!("D24S8: {:?}", device.d24_s8_supported());
+    #[cfg(target_os = "macos")]
+    {
+        println!("Integrated GPU: {:?}", device.is_low_power());
+        println!("Headless: {:?}", device.is_headless());
+        println!("D24S8: {:?}", device.d24_s8_supported());
+    }
     println!("Indirect argument buffer: {:?}", device.argument_buffers_support());
 }

--- a/examples/compute/compute-argument-buffer.rs
+++ b/examples/compute/compute-argument-buffer.rs
@@ -62,7 +62,10 @@ fn main() {
     let pipeline_state_descriptor = ComputePipelineDescriptor::new();
     pipeline_state_descriptor.set_compute_function(Some(&kernel));
 
-    let pipeline_state = device.new_compute_pipeline_state(&pipeline_state_descriptor).unwrap();
+    let pipeline_state = device
+        .new_compute_pipeline_state_with_function(
+            pipeline_state_descriptor.compute_function().unwrap(),
+        ).unwrap();
 
     encoder.set_compute_pipeline_state(&pipeline_state);
     encoder.set_buffer(0, Some(&arg_buffer), 0);

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -54,7 +54,10 @@ fn main() {
     let pipeline_state_descriptor = ComputePipelineDescriptor::new();
     pipeline_state_descriptor.set_compute_function(Some(&kernel));
 
-    let pipeline_state = device.new_compute_pipeline_state(&pipeline_state_descriptor).unwrap();
+    let pipeline_state = device
+        .new_compute_pipeline_state_with_function(
+            pipeline_state_descriptor.compute_function().unwrap()
+        ).unwrap();
 
     encoder.set_compute_pipeline_state(&pipeline_state);
     encoder.set_buffer(0, Some(&buffer), 0);

--- a/examples/reflection/main.rs
+++ b/examples/reflection/main.rs
@@ -63,6 +63,7 @@ fn main() {
 
     println!("{:?}", desc);
 
+    #[cfg(features = "private")]
     let _reflection = unsafe { RenderPipelineReflection::new(
         desc.serialize_vertex_data(),
         desc.serialize_fragment_data(),

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -92,6 +92,22 @@ pub enum MTLDataType {
     Texture = 58,
     Sampler = 59,
     Pointer = 60,
+    R8Unorm = 62,
+    R8Snorm = 63,
+    R16Unorm = 64,
+    R16Snorm = 65,
+    RG8Unorm = 66,
+    RG8Snorm = 67,
+    RG16Unorm = 68,
+    RG16Snorm = 69,
+    RGBA8Unorm = 70,
+    RGBA8Unorm_sRGB = 71,
+    RGBA8Snorm = 72,
+    RGBA16Unorm = 73,
+    RGBA16Snorm = 74,
+    RGB10A2Unorm = 75,
+    RG11B10Float = 76,
+    RGB9E5Float = 77,
 }
 
 #[repr(u32)]
@@ -101,6 +117,8 @@ pub enum MTLArgumentType {
     ThreadgroupMemory = 1,
     Texture = 2,
     Sampler = 3,
+    ImageblockData = 16,
+    Imageblock = 17,
 }
 
 #[repr(u32)]

--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -32,6 +32,8 @@ pub enum MTLCommandBufferError {
     NotPermitted = 7,
     OutOfMemory = 8,
     InvalidResource = 9,
+    Memoryless = 10,
+    DeviceRemoved = 11,
 }
 
 type _MTLCommandBufferHandler = Block<(MTLCommandBuffer), ()>;

--- a/src/device.rs
+++ b/src/device.rs
@@ -36,10 +36,18 @@ pub enum MTLFeatureSet {
     iOS_GPUFamily2_v4 = 9,
     iOS_GPUFamily3_v3 = 10,
     iOS_GPUFamily4_v1 = 11,
+    // iOS_GPUFamily1_v5 = 12, TODO: Uncomment when feature tables updated
+    // iOS_GPUFamily2_v5 = 13,
+    // iOS_GPUFamily3_v4 = 14,
+    // iOS_GPUFamily4_v2 = 15,
+    
     tvOS_GPUFamily1_v1 = 30000,
     tvOS_GPUFamily1_v2 = 30001,
     tvOS_GPUFamily1_v3 = 30002,
     tvOS_GPUFamily2_v1 = 30003,
+    // tvOS_GPUFamily1_v4 = 30004,
+    // tvOS_GPUFamily2_v2 = 30005,
+
     macOS_GPUFamily1_v1 = 10000,
     macOS_GPUFamily1_v2 = 10001,
     //macOS_ReadWriteTextureTier2 = 10002, TODO: Uncomment when feature tables updated
@@ -1355,18 +1363,16 @@ impl DeviceRef {
         }
     }
 
-    pub fn vendor(&self) -> &str {
-        unsafe {
-            let name: &NSString = msg_send![self, vendorName];
-            name.as_str()
-        }
+    #[cfg(feature = "private")]
+    pub unsafe fn vendor(&self) -> &str {
+        let name: &NSString = msg_send![self, vendorName];
+        name.as_str()
     }
 
-    pub fn family_name(&self) -> &str {
-        unsafe {
-            let name: &NSString = msg_send![self, familyName];
-            name.as_str()
-        }
+    #[cfg(feature = "private")]
+    pub unsafe fn family_name(&self) -> &str {
+        let name: &NSString = msg_send![self, familyName];
+        name.as_str()
     }
 
     pub fn registry_id(&self) -> u64 {
@@ -1538,15 +1544,25 @@ impl DeviceRef {
         }
     }
 
-    pub fn new_compute_pipeline_state(&self, descriptor: &ComputePipelineDescriptorRef) -> Result<ComputePipelineState, String> {
+    pub fn new_compute_pipeline_state_with_function(&self, function: &FunctionRef) -> Result<ComputePipelineState, String> {
         unsafe {
             let pipeline_state: *mut MTLComputePipelineState = try_objc!{ err =>
-                msg_send![self, newComputePipelineStateWithDescriptor:descriptor
-                                                               error:&mut err]
+                msg_send![self, newComputePipelineStateWithFunction:function
+                                                              error:&mut err]
             };
 
             Ok(ComputePipelineState::from_ptr(pipeline_state))
         }
+    }
+
+    #[cfg(feature = "private")]
+    pub unsafe fn new_compute_pipeline_state(&self, descriptor: &ComputePipelineDescriptorRef) -> Result<ComputePipelineState, String> {
+        let pipeline_state: *mut MTLComputePipelineState = try_objc!{ err =>
+            msg_send![self, newComputePipelineStateWithDescriptor:descriptor
+                                                            error:&mut err]
+        };
+
+        Ok(ComputePipelineState::from_ptr(pipeline_state))
     }
 
     pub fn new_buffer(&self, length: u64, options: MTLResourceOptions) -> Buffer {

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -50,7 +50,7 @@ impl HeapRef {
 
     pub fn max_available_size(&self, alignment: NSUInteger) -> NSUInteger {
         unsafe {
-            msg_send![self, maxAvailableSize: alignment]
+            msg_send![self, maxAvailableSizeWithAlignment: alignment]
         }
     }
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -200,14 +200,6 @@ pub enum MTLLibraryError {
     CompileWarning   = 4,
 }
 
-#[repr(u64)]
-#[allow(non_camel_case_types)]
-pub enum MTLRenderPipelineError {
-    Internal          = 1,
-    Unsupported       = 2,
-    InvalidInput      = 3,
-}
-
 pub enum MTLLibrary {}
 
 foreign_obj_type! {

--- a/src/pipeline/compute.rs
+++ b/src/pipeline/compute.rs
@@ -81,6 +81,16 @@ pub enum MTLAttributeFormat {
     UInt4 = 39,
     Int1010102Normalized = 40,
     UInt1010102Normalized = 41,
+    UChar4Normalized_BGRA = 42,
+    UChar = 45,
+    Char = 46,
+    UCharNormalized = 47,
+    CharNormalized = 48,
+    UShort = 49,
+    Short = 50,
+    UShortNormalized = 51,
+    ShortNormalized = 52,
+    Half = 53,
 }
 
 #[repr(u64)]

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -8,9 +8,10 @@
 use super::*;
 
 use cocoa::foundation::NSUInteger;
-use objc::runtime::{Object, YES, NO};
+use objc::runtime::{YES, NO};
 use objc_foundation::{INSString, NSString};
 
+#[cfg(feature = "private")]
 use libc;
 
 #[repr(u64)]
@@ -199,6 +200,7 @@ foreign_obj_type! {
 }
 
 impl RenderPipelineReflection {
+    #[cfg(feature = "private")]
     pub unsafe fn new(vertex_data: *mut libc::c_void,
             fragment_data: *mut libc::c_void, vertex_desc: *mut libc::c_void,
             device: &DeviceRef, options: u64, flags: u64) -> Self
@@ -402,6 +404,7 @@ impl RenderPipelineDescriptorRef {
         }
     }
 
+    #[cfg(feature = "private")]
     pub unsafe fn serialize_vertex_data(&self) -> *mut libc::c_void {
         use std::ptr;
         let flags = 0;
@@ -410,6 +413,7 @@ impl RenderPipelineDescriptorRef {
                                                     error:err]
     }
 
+    #[cfg(feature = "private")]
     pub unsafe fn serialize_fragment_data(&self) -> *mut libc::c_void {
         msg_send![self, serializeFragmentData]
     }

--- a/src/renderpass.rs
+++ b/src/renderpass.rs
@@ -23,6 +23,9 @@ pub enum MTLStoreAction {
     DontCare = 0,
     Store = 1,
     MultisampleResolve = 2,
+    StoreAndMultisampleResolve = 3,
+    Unknown = 4,
+    CustomSampleDepthStore = 5,
 }
 
 #[repr(C)]

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -33,6 +33,7 @@ pub enum MTLStorageMode {
     Shared  = 0,
     Managed = 1,
     Private = 2,
+    Memoryless = 3,
 }
 
 pub const MTLResourceCPUCacheModeShift: NSUInteger = 0;
@@ -49,6 +50,7 @@ bitflags! {
         const StorageModeShared  = (MTLStorageMode::Shared as NSUInteger)  << MTLResourceStorageModeShift;
         const StorageModeManaged = (MTLStorageMode::Managed as NSUInteger) << MTLResourceStorageModeShift;
         const StorageModePrivate = (MTLStorageMode::Private as NSUInteger) << MTLResourceStorageModeShift;
+        const StorageModeMemoryless = (MTLStorageMode::Memoryless as NSUInteger) << MTLResourceStorageModeShift;
     }
 }
 

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -110,10 +110,9 @@ impl SamplerDescriptorRef {
         }
     }
 
-    pub fn set_lod_bias(&self, bias: f32) {
-        unsafe {
-            msg_send![self, setLodBias:bias]
-        }
+    #[cfg(feature = "private")]
+    pub unsafe fn set_lod_bias(&self, bias: f32) {
+        msg_send![self, setLodBias:bias]
     }
 
     pub fn set_lod_min_clamp(&self, clamp: f32) {

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -209,6 +209,7 @@ foreign_obj_type! {
 }
 
 impl TextureRef {
+    #[deprecated(since="0.13.0")]
     pub fn root_resource(&self) -> Option<&ResourceRef> {
        unsafe {
            msg_send![self, rootResource]

--- a/src/vertexdescriptor.rs
+++ b/src/vertexdescriptor.rs
@@ -7,6 +7,7 @@
 
 use cocoa::foundation::NSUInteger;
 
+#[cfg(feature = "private")]
 use libc;
 
 #[repr(u64)]
@@ -72,6 +73,8 @@ pub enum MTLVertexStepFunction {
     Constant = 0,
     PerVertex = 1,
     PerInstance = 2,
+    PerPatch = 3,
+    PerPatchControlPoint = 4,
 }
 
 pub enum MTLVertexBufferLayoutDescriptor {}
@@ -260,6 +263,7 @@ impl VertexDescriptorRef {
         }
     }
 
+    #[cfg(feature = "private")]
     pub unsafe fn serialize_descriptor(&self) -> *mut libc::c_void {
         msg_send![self, newSerializedDescriptor]
     }


### PR DESCRIPTION
While working on getting the gfx/quad example going, I ran into some metal calls that are unsupported on iOS. So I did a pass on all the ffi for os compatibility, and fixed things where I could.

- metal-rs is using some private APIs, and apple has a history of rejecting apps from the app store for doing that
- there's no managed memory on iOS
- there's no layered rendering on iOS

- iOS 8.0 is missing some features from osx 10.11
- iOS 9.0 is roughly equivalent in metal support to osx 10.11
- iOS 10.0 is roughly equivalent in metal support to osx 10.12
- iOS 11.0 is roughly equivalent in metal support to osx 10.13

I added a bunch of comments above things that were unsupported on various os versions. Should I leave those in or nuke'em?

This breaks gfx-rs on iOS. I'll make a PR there shortly as well.