### PR TITLE
add MTLLanguageVersion 2.1

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -111,6 +111,7 @@ pub enum MTLLanguageVersion {
     V1_1 = 0x10001,
     V1_2 = 0x10002,
     V2_0 = 0x20000,
+    V2_1 = 0x20001,
 }
 
 pub enum MTLFunctionConstantValues {}


### PR DESCRIPTION
Missed this from the last PR. `0.14.0` has not been published, so I think this can squeeze in without a version bump.

@kvark Is there anything else in metal-rs that should be updated when new OS Versions come out? If so, I'll try and add it into this PR.