### PR TITLE
Bump winit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ version = "0.2.4"
 features = ["objc_exception"]
 
 [dev-dependencies]
-winit = "0.17"
+winit = "0.19"
 sema = "0.1.4"
 
 


### PR DESCRIPTION
The version of winit used in the window example pins an old version of cocoa lacking a soundness fix (servo/core-foundation-rs#340) for undefined behavior in an upcoming version of rust (rust-lang/rust#65355).

Testing done: ran the window example after this change; it compiles and looks fine!