### PR TITLE
Support Vertex Amplification.

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1485,6 +1485,16 @@ impl DeviceRef {
         }
     }
 
+    pub fn supports_vertex_amplification_count(&self, count: NSUInteger) -> bool {
+        unsafe {
+            match msg_send![self, supportsVertexAmplificationCount: count] {
+                YES => true,
+                NO => false,
+                _ => unreachable!(),
+            }
+        }
+    }
+
     pub fn supports_sample_count(&self, count: NSUInteger) -> bool {
         unsafe {
             match msg_send![self, supportsTextureSampleCount: count] {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -113,6 +113,13 @@ pub struct MTLDrawIndexedPrimitivesIndirectArguments {
     pub baseInstance: u32,
 }
 
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct VertexAmplificationViewMapping {
+    pub renderTargetArrayIndexOffset: u32,
+    pub viewportArrayIndexOffset: u32,
+}
+
 pub enum MTLCommandEncoder {}
 
 foreign_obj_type! {
@@ -137,9 +144,7 @@ impl CommandEncoderRef {
     }
 
     pub fn end_encoding(&self) {
-        unsafe {
-            msg_send![self, endEncoding]
-        }
+        unsafe { msg_send![self, endEncoding] }
     }
 
     pub fn insert_debug_signpost(&self, name: &str) {
@@ -157,9 +162,7 @@ impl CommandEncoderRef {
     }
 
     pub fn pop_debug_group(&self) {
-        unsafe {
-            msg_send![self, popDebugGroup]
-        }
+        unsafe { msg_send![self, popDebugGroup] }
     }
 }
 
@@ -255,6 +258,16 @@ impl RenderCommandEncoderRef {
         }
     }
 
+    pub fn set_vertex_amplification_count(
+        &self,
+        count: NSUInteger,
+        view_mappings: Option<&[VertexAmplificationViewMapping]>,
+    ) {
+        unsafe {
+            msg_send! [self, setVertexAmplificationCount: count viewMappings: view_mappings.map_or(std::ptr::null(), |vm| vm.as_ptr())]
+        }
+    }
+
     // Specifying Resources for a Vertex Shader Function
 
     pub fn set_vertex_bytes(
@@ -287,11 +300,7 @@ impl RenderCommandEncoderRef {
         }
     }
 
-    pub fn set_vertex_buffer_offset(
-        &self,
-        index: NSUInteger,
-        offset: NSUInteger,
-    ) {
+    pub fn set_vertex_buffer_offset(&self, index: NSUInteger, offset: NSUInteger) {
         unsafe {
             msg_send![self,
                 setVertexBufferOffset:offset
@@ -413,11 +422,7 @@ impl RenderCommandEncoderRef {
         }
     }
 
-    pub fn set_fragment_buffer_offset(
-        &self,
-        index: NSUInteger,
-        offset: NSUInteger,
-    ) {
+    pub fn set_fragment_buffer_offset(&self, index: NSUInteger, offset: NSUInteger) {
         unsafe {
             msg_send![self,
                 setFragmentBufferOffset:offset
@@ -1031,12 +1036,7 @@ impl ArgumentEncoderRef {
         }
     }
 
-    pub fn set_buffer(
-        &self,
-        at_index: NSUInteger,
-        buffer: &BufferRef,
-        offset: NSUInteger,
-    ) {
+    pub fn set_buffer(&self, at_index: NSUInteger, buffer: &BufferRef, offset: NSUInteger) {
         unsafe {
             msg_send![self,
                 setBuffer: buffer

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -260,6 +260,14 @@ impl RenderPipelineDescriptorRef {
         unsafe { msg_send![self, setSampleCount: count] }
     }
 
+    pub fn max_vertex_amplification_count(&self) -> NSUInteger {
+        unsafe { msg_send![self, maxVertexAmplificationCount] }
+    }
+
+    pub fn set_max_vertex_amplification_count(&self, count: NSUInteger) {
+        unsafe { msg_send![self, setMaxVertexAmplificationCount: count] }
+    }
+
     pub fn is_alpha_to_coverage_enabled(&self) -> bool {
         unsafe {
             match msg_send![self, isAlphaToCoverageEnabled] {
@@ -404,7 +412,10 @@ foreign_obj_type! {
 }
 
 impl RenderPipelineColorAttachmentDescriptorArrayRef {
-    pub fn object_at(&self, index: NSUInteger) -> Option<&RenderPipelineColorAttachmentDescriptorRef> {
+    pub fn object_at(
+        &self,
+        index: NSUInteger,
+    ) -> Option<&RenderPipelineColorAttachmentDescriptorRef> {
         unsafe { msg_send![self, objectAtIndexedSubscript: index] }
     }
 


### PR DESCRIPTION
This PR adds support for Vertex Amplification which is a new feature in Metal. Details of vertex amplification is available here: https://developer.apple.com/documentation/metal/generating_multiple_output_vertex_streams_from_one_input_stream?language=objc