### PR TITLE
Use more persistent shader type cache dir

### DIFF
--- a/examples/texture/.gitignore
+++ b/examples/texture/.gitignore
@@ -1,1 +1,2 @@
 shaders.metallib
+shader_types_hash

--- a/examples/texture/build.rs
+++ b/examples/texture/build.rs
@@ -106,5 +106,5 @@ fn save_shader_types_hash(hash: u64) {
 }
 
 fn shader_types_hash_file() -> PathBuf {
-    PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("shader_types_hash")
+    PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("shader_types_hash")
 }

--- a/examples/texture/shader_types/shader_types.h
+++ b/examples/texture/shader_types/shader_types.h
@@ -5,7 +5,10 @@
 #ifndef shader_types_h
 #define shader_types_h
 
-#include <simd/simd.h>
+// Used to get the definition of vector_float2
+// If you need to import more types, simd is typically located at:
+// /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/simd
+#include <simd/vector_types.h>
 
 typedef enum VertexInputIndex {
     VertexInputIndexVertices = 0,


### PR DESCRIPTION
Because the `OUT_DIR` environment variable can change, the shader bindings cache would get invalidated sometimes leading to a recompilation of shader bindings.

Generating the bindings is a slow process and should be avoided.

This PR creates a directory in the crate to use for caching since having a consistent cache directory means shader type re-compilation becomes rare.

To further reduce the cost of these bindings, I changed the `shader_types.rs` file to only include `simd/vector_types.h` instead of all of `simd/simd.h`. 

This takes a `cargo build -p texture` after editing `shader_types.h` from 16seconds to around 9.7 seconds on my machine (effectively all of that time is spent generating the Rust bindings).

We're really only using one type from that file (vector_float2), but I didn't spend time further investigating how to reduce the amount of simd that we're needlessly compiling (I did investigate rust bindgen whitelists/blacklists but those just control what ends up in the final generating bindings. So no time is saved by white/blacklisting things as far as I can tell).

