### PR TITLE
[0.18] Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metal"
-version = "0.18.0"
+version = "0.18.1"
 description = "Rust bindings for Metal"
 documentation = "https://docs.rs/crate/metal"
 homepage = "https://github.com/gfx-rs/metal-rs"
@@ -19,8 +19,8 @@ default = []
 private = []
 
 [dependencies]
-cocoa = "0.20"
-core-graphics = "0.19"
+cocoa = "0.22"
+core-graphics = "0.21"
 bitflags = "1"
 log = "0.4"
 block = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ private = []
 
 [dependencies]
 cocoa = "0.22"
-core-graphics = "0.21"
 bitflags = "1"
 log = "0.4"
 block = "0.1.5"

--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -13,9 +13,8 @@ use cocoa::{
     foundation::{NSRange},
 };
 
-use core_graphics::geometry::CGSize;
-use objc::runtime::YES;
 use metal::*;
+use objc::runtime::YES;
 use winit::platform::macos::WindowExtMacOS;
 use std::mem;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,27 @@ use std::mem;
 use std::ops::Deref;
 use std::os::raw::c_void;
 
-use core_graphics::base::CGFloat;
-use core_graphics::geometry::CGSize;
+use cocoa::foundation::NSUInteger;
 use foreign_types::ForeignType;
 use objc::runtime::{Object, NO, YES};
-use cocoa::foundation::NSUInteger;
+
+#[cfg(target_pointer_width = "64")]
+pub type CGFloat = f64;
+#[cfg(not(target_pointer_width = "64"))]
+pub type CGFloat = f32;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct CGSize {
+    pub width: CGFloat,
+    pub height: CGFloat,
+}
+
+impl CGSize {
+    pub fn new(width: f64, height: f64) -> Self {
+        CGSize { width, height }
+    }
+}
 
 fn nsstring_as_str(nsstr: &objc::runtime::Object) -> &str {
     let bytes = unsafe {

--- a/src/pipeline/compute.rs
+++ b/src/pipeline/compute.rs
@@ -13,14 +13,6 @@ use objc::runtime::{NO, YES};
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub enum MTLIndexType {
-    UInt16 = 0,
-    UInt32 = 1,
-}
-
-#[repr(u64)]
-#[allow(non_camel_case_types)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLAttributeFormat {
     Invalid = 0,
     UChar2 = 1,


### PR DESCRIPTION
This is a little bit risky, since there are parts of `cocoa` that we expose in public API (e.g. `NSUInteger`), so updating the breaking version of it is technically also a breaking change... But it's fine as long as both versions of cocoa just typedef it to the same thing, e.g. `u64`.
If there is a way in Rust to know *all* of the public uses of a dependency, it would be handy here.