### PR TITLE
Switch from cocoa to cocoa_foundation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 private = []
 
 [dependencies]
-cocoa = "0.22"
+cocoa-foundation = "0.1"
 bitflags = "1"
 log = "0.4"
 block = "0.1.5"
@@ -31,6 +31,7 @@ version = "0.2.4"
 features = ["objc_exception"]
 
 [dev-dependencies]
+cocoa = "0.23"
 cty = "0.2.1"
 winit = "0.22"
 sema = "0.1.4"

--- a/examples/texture/Cargo.toml
+++ b/examples/texture/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 bindgen = "0.53.2"
 
 [dependencies]
-cocoa = "0.22"
-core-graphics = "0.21"
+cocoa = "0.23"
+core-graphics = "0.22"
 png = "0.16"
 metal = { path = "../../" }
 winit = "0.22"

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -7,7 +7,7 @@
 
 use crate::{Array, MTLTextureType};
 
-use cocoa::foundation::NSUInteger;
+use cocoa_foundation::foundation::NSUInteger;
 use objc::runtime::{NO, YES};
 
 #[repr(u64)]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-use cocoa::foundation::NSRange;
+use cocoa_foundation::foundation::NSRange;
 
 pub enum MTLBuffer {}
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -6,8 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 
 use block::{Block, ConcreteBlock};
-use cocoa::base::id;
-use cocoa::foundation::NSUInteger;
+use cocoa_foundation::base::id;
+use cocoa_foundation::foundation::NSUInteger;
 use foreign_types::ForeignType;
 use objc::runtime::{Object, BOOL, NO, YES};
 
@@ -1535,8 +1535,8 @@ impl DeviceRef {
         src: &str,
         options: &CompileOptionsRef,
     ) -> Result<Library, String> {
-        use cocoa::base::nil as cocoa_nil;
-        use cocoa::foundation::NSString as cocoa_NSString;
+        use cocoa_foundation::base::nil as cocoa_nil;
+        use cocoa_foundation::foundation::NSString as cocoa_NSString;
 
         unsafe {
             let source = cocoa_NSString::alloc(cocoa_nil).init_str(src);
@@ -1563,8 +1563,8 @@ impl DeviceRef {
     }
 
     pub fn new_library_with_file<P: AsRef<Path>>(&self, file: P) -> Result<Library, String> {
-        use cocoa::base::nil as cocoa_nil;
-        use cocoa::foundation::NSString as cocoa_NSString;
+        use cocoa_foundation::base::nil as cocoa_nil;
+        use cocoa_foundation::foundation::NSString as cocoa_NSString;
 
         unsafe {
             let filename =

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-use cocoa::foundation::{NSInteger, NSRange, NSUInteger};
+use cocoa_foundation::foundation::{NSInteger, NSRange, NSUInteger};
 
 use std::ops::Range;
 

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-use cocoa::foundation::NSUInteger;
+use cocoa_foundation::foundation::NSUInteger;
 
 pub enum MTLHeap {}
 

--- a/src/indirect_encoder.rs
+++ b/src/indirect_encoder.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use cocoa::foundation::{NSRange, NSUInteger};
+use cocoa_foundation::foundation::{NSRange, NSUInteger};
 
 bitflags! {
     #[allow(non_upper_case_globals)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use std::mem;
 use std::ops::Deref;
 use std::os::raw::c_void;
 
-use cocoa::foundation::NSUInteger;
+use cocoa_foundation::foundation::NSUInteger;
 use foreign_types::ForeignType;
 use objc::runtime::{Object, BOOL, NO, YES};
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-use cocoa::foundation::NSUInteger;
+use cocoa_foundation::foundation::NSUInteger;
 use foreign_types::ForeignType;
 use objc::runtime::{Object, NO, YES};
 use std::ffi::CStr;

--- a/src/pipeline/compute.rs
+++ b/src/pipeline/compute.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-use cocoa::foundation::NSUInteger;
+use cocoa_foundation::foundation::NSUInteger;
 use objc::runtime::{NO, YES};
 
 #[repr(u64)]

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-use cocoa::foundation::NSUInteger;
+use cocoa_foundation::foundation::NSUInteger;
 use objc::runtime::{NO, YES};
 
 #[repr(u64)]

--- a/src/renderpass.rs
+++ b/src/renderpass.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-use cocoa::foundation::NSUInteger;
+use cocoa_foundation::foundation::NSUInteger;
 
 #[repr(u64)]
 #[derive(Copy, Clone, Debug)]

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use super::DeviceRef;
-use cocoa::foundation::NSUInteger;
+use cocoa_foundation::foundation::NSUInteger;
 
 #[repr(u64)]
 #[allow(non_camel_case_types)]

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use cocoa::foundation::NSUInteger;
+use cocoa_foundation::foundation::NSUInteger;
 
 use crate::depthstencil::MTLCompareFunction;
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-use cocoa::foundation::{NSRange, NSUInteger};
+use cocoa_foundation::foundation::{NSRange, NSUInteger};
 use objc::runtime::{NO, YES};
 
 #[repr(u64)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use cocoa::foundation::NSUInteger;
+use cocoa_foundation::foundation::NSUInteger;
 use std::default::Default;
 
 #[repr(C)]

--- a/src/vertexdescriptor.rs
+++ b/src/vertexdescriptor.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use cocoa::foundation::NSUInteger;
+use cocoa_foundation::foundation::NSUInteger;
 
 #[repr(u64)]
 #[allow(non_camel_case_types)]


### PR DESCRIPTION
This replaces the implicit dependency on core-graphics with one on
core-graphics-types which should reduce dependency churn.

Also fewer dependencies means less build time.