### PR TITLE
added RenderCommandEncoder set_vertex_value + set_fragment_value

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1680,6 +1680,16 @@ impl DeviceRef {
         }
     }
 
+    #[inline]
+    pub fn new_buffer_with_value<T>(&self, value: &T, options: MTLResourceOptions) -> Buffer {
+        let ptr = value as *const T;
+        self.new_buffer_with_data(
+            ptr as *const _,
+            std::mem::size_of::<T>() as NSUInteger,
+            options,
+        )
+    }
+
     pub fn new_texture(&self, descriptor: &TextureDescriptorRef) -> Texture {
         unsafe { msg_send![self, newTextureWithDescriptor: descriptor] }
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -978,6 +978,16 @@ impl ComputeCommandEncoderRef {
         }
     }
 
+    #[inline]
+    pub fn set_value<T>(&self, index: NSUInteger, value: &T) {
+        let ptr = value as *const T;
+        self.set_bytes(
+            index,
+            std::mem::size_of::<T>() as NSUInteger,
+            ptr as *const _,
+        )
+    }
+
     pub fn dispatch_thread_groups(
         &self,
         thread_groups_count: MTLSize,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -286,6 +286,16 @@ impl RenderCommandEncoderRef {
         }
     }
 
+    #[inline]
+    pub fn set_vertex_value<T>(&self, index: NSUInteger, value: &T) {
+        let ptr = value as *const T;
+        self.set_vertex_bytes(
+            index,
+            std::mem::size_of::<T>() as NSUInteger,
+            ptr as *const _,
+        )
+    }
+
     pub fn set_vertex_buffer(
         &self,
         index: NSUInteger,
@@ -406,6 +416,16 @@ impl RenderCommandEncoderRef {
                 atIndex:index
             ]
         }
+    }
+
+    #[inline]
+    pub fn set_fragment_value<T>(&self, index: NSUInteger, value: &T) {
+        let ptr = value as *const T;
+        self.set_fragment_bytes(
+            index,
+            std::mem::size_of::<T>() as NSUInteger,
+            ptr as *const _,
+        )
     }
 
     pub fn set_fragment_buffer(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,6 +370,20 @@ impl CoreAnimationLayerRef {
     pub fn set_framebuffer_only(&self, framebuffer_only: BOOL) {
         unsafe { msg_send![self, setFramebufferOnly: framebuffer_only] }
     }
+
+    pub fn is_opaque(&self) -> bool {
+        unsafe {
+            match msg_send![self, isOpaque] {
+                YES => true,
+                NO => false,
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    pub fn set_opaque(&self, opaque: bool) {
+        unsafe { msg_send![self, setOpaque: opaque] }
+    }
 }
 
 mod argument;


### PR DESCRIPTION
I realize this is probably a matter of taste but the original API is really unwieldy in Rust. @chinedufn 