### PR TITLE
renderpipelinestate only has a label getter, you set the label on the…

### DIFF
--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -398,13 +398,6 @@ impl RenderPipelineStateRef {
             crate::nsstring_as_str(label)
         }
     }
-
-    pub fn set_label(&self, label: &str) {
-        unsafe {
-            let nslabel = crate::nsstring_from_str(label);
-            let () = msg_send![self, setLabel: nslabel];
-        }
-    }
 }
 
 pub enum MTLRenderPipelineColorAttachmentDescriptorArray {}


### PR DESCRIPTION
… descriptor.

These pull requests are as much lol for me as for you.

https://developer.apple.com/documentation/metal/mtlrenderpipelinestate/1514621-label
