### PR TITLE
Add sync primitives 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ name = "bind"
 [[example]]
 name = "events"
 
+[[example]]
+name = "fence"
+
 [workspace]
 members = [
   "examples/texture",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metal"
-version = "0.20.0"
+version = "0.20.1"
 description = "Rust bindings for Metal"
 documentation = "https://docs.rs/crate/metal"
 homepage = "https://github.com/gfx-rs/metal-rs"
@@ -18,6 +18,7 @@ default-target = "x86_64-apple-darwin"
 [features]
 default = []
 private = []
+dispatch-queue = ["dispatch"]
 
 [dependencies]
 cocoa-foundation = "0.1"
@@ -25,6 +26,7 @@ bitflags = "1"
 log = "0.4"
 block = "0.1.5"
 foreign-types = "0.3"
+dispatch = { version = "0.2.0", optional = true }
 
 [dependencies.objc]
 version = "0.2.4"
@@ -76,6 +78,7 @@ name = "bind"
 
 [[example]]
 name = "events"
+required-features = ["dispatch-queue"]
 
 [[example]]
 name = "fence"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,9 @@ path = "examples/compute/compute-argument-buffer.rs"
 [[example]]
 name = "bind"
 
+[[example]]
+name = "events"
+
 [workspace]
 members = [
   "examples/texture",

--- a/examples/events/main.rs
+++ b/examples/events/main.rs
@@ -1,0 +1,50 @@
+// Copyright 2017 GFX developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use metal::*;
+use std::ffi::CString;
+
+/// This example replicates `Synchronizing Events Between a GPU and the CPU` article.
+/// See https://developer.apple.com/documentation/metal/synchronization/synchronizing_events_between_a_gpu_and_the_cpu
+fn main() {
+    let device = Device::system_default().expect("No device found");
+
+    let command_queue = device.new_command_queue();
+    let command_buffer = command_queue.new_command_buffer();
+
+    // Shareable event
+    let shared_event = device.new_shared_event();
+
+    // Shareable event listener
+    let my_queue = unsafe {
+        let label = CString::new("com.example.apple-samplecode.MyQueue").unwrap();
+        dispatch_queue_create(label.as_ptr(), std::ptr::null())
+    };
+
+    let shared_event_listener = unsafe { SharedEventListener::from_dispatch_queue(my_queue) };
+
+    // Register CPU work
+    let notify_block = block::ConcreteBlock::new(move |evt: &SharedEventRef, val: u64| {
+        println!("Got notification from GPU: {}", val);
+        evt.set_signaled_value(3);
+    });
+
+    shared_event.notify(&shared_event_listener, 2, notify_block.copy());
+
+    // Encode GPU work
+    command_buffer.encode_signal_event(&shared_event, 1);
+    command_buffer.encode_signal_event(&shared_event, 2);
+    command_buffer.encode_wait_for_event(&shared_event, 3);
+
+    command_buffer.commit();
+
+    command_buffer.wait_until_completed();
+
+    println!("Done");
+
+    unsafe { dispatch_release(my_queue) };
+}

--- a/examples/fence/main.rs
+++ b/examples/fence/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 GFX developers
+// Copyright 2020 GFX developers
 //
 // Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or

--- a/examples/fence/main.rs
+++ b/examples/fence/main.rs
@@ -1,0 +1,30 @@
+// Copyright 2017 GFX developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use metal::*;
+
+fn main() {
+    let device = Device::system_default().expect("No device found");
+
+    let command_queue = device.new_command_queue();
+    let command_buffer = command_queue.new_command_buffer();
+
+    let fence = device.new_fence();
+
+    let blit_encoder = command_buffer.new_blit_command_encoder();
+    blit_encoder.update_fence(&fence);
+    blit_encoder.end_encoding();
+
+    let compute_encoder = command_buffer.new_compute_command_encoder();
+    compute_encoder.wait_for_fence(&fence);
+    compute_encoder.end_encoding();
+
+    command_buffer.commit();
+    command_buffer.wait_until_completed();
+
+    println!("Done");
+}

--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -126,4 +126,22 @@ impl CommandBufferRef {
     ) -> &ComputeCommandEncoderRef {
         unsafe { msg_send![self, computeCommandEncoderWithDispatchType: ty] }
     }
+
+    pub fn encode_signal_event(&self, event: &EventRef, new_value: u64) {
+        unsafe {
+            msg_send![self,
+                encodeSignalEvent: event
+                value: new_value
+            ]
+        }
+    }
+
+    pub fn encode_wait_for_event(&self, event: &EventRef, value: u64) {
+        unsafe {
+            msg_send![self,
+                encodeWaitForEvent: event
+                value: value
+            ]
+        }
+    }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1372,12 +1372,7 @@ extern "C" {
         queue: dispatch_queue_t,
         destructor: dispatch_block_t,
     ) -> dispatch_data_t;
-    pub fn dispatch_release(object: dispatch_data_t); // actually dispatch_object_t
-
-    pub fn dispatch_queue_create(
-        label: *const std::os::raw::c_char,
-        attr: *const std::ffi::c_void,
-    ) -> dispatch_queue_t;
+    fn dispatch_release(object: dispatch_data_t); // actually dispatch_object_t
 }
 
 /*type MTLNewLibraryCompletionHandler = extern fn(library: id, error: id);

--- a/src/device.rs
+++ b/src/device.rs
@@ -1731,6 +1731,10 @@ impl DeviceRef {
         unsafe { msg_send![self, newSharedEvent] }
     }
 
+    pub fn new_fence(&self) -> Fence {
+        unsafe { msg_send![self, newFence] }
+    }
+
     pub fn heap_buffer_size_and_align(
         &self,
         length: NSUInteger,

--- a/src/device.rs
+++ b/src/device.rs
@@ -1350,7 +1350,7 @@ extern "C" {
 #[allow(non_camel_case_types)]
 type dispatch_data_t = id;
 #[allow(non_camel_case_types)]
-type dispatch_queue_t = id;
+pub type dispatch_queue_t = id;
 #[allow(non_camel_case_types)]
 type dispatch_block_t = *const Block<(), ()>;
 
@@ -1372,7 +1372,12 @@ extern "C" {
         queue: dispatch_queue_t,
         destructor: dispatch_block_t,
     ) -> dispatch_data_t;
-    fn dispatch_release(object: dispatch_data_t); // actually dispatch_object_t
+    pub fn dispatch_release(object: dispatch_data_t); // actually dispatch_object_t
+
+    pub fn dispatch_queue_create(
+        label: *const std::os::raw::c_char,
+        attr: *const std::ffi::c_void,
+    ) -> dispatch_queue_t;
 }
 
 /*type MTLNewLibraryCompletionHandler = extern fn(library: id, error: id);
@@ -1716,6 +1721,14 @@ impl DeviceRef {
 
     pub fn new_heap(&self, descriptor: &HeapDescriptorRef) -> Heap {
         unsafe { msg_send![self, newHeapWithDescriptor: descriptor] }
+    }
+
+    pub fn new_event(&self) -> Event {
+        unsafe { msg_send![self, newEvent] }
+    }
+
+    pub fn new_shared_event(&self) -> SharedEvent {
+        unsafe { msg_send![self, newSharedEvent] }
     }
 
     pub fn heap_buffer_size_and_align(

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -680,6 +680,24 @@ impl RenderCommandEncoderRef {
     pub fn use_heap(&self, heap: &HeapRef) {
         unsafe { msg_send![self, useHeap: heap] }
     }
+
+    pub fn update_fence(&self, fence: FenceRef, after_stages: MTLRenderStages) {
+        unsafe {
+            msg_send![self,
+                updateFence: fence
+                afterStages: after_stages
+            ]
+        }
+    }
+
+    pub fn wait_for_fence(&self, fence: FenceRef, before_stages: MTLRenderStages) {
+        unsafe {
+            msg_send![self,
+                waitForFence: fence
+                beforeStages: before_stages
+            ]
+        }
+    }
 }
 
 pub enum MTLBlitCommandEncoder {}
@@ -851,6 +869,14 @@ impl BlitCommandEncoderRef {
             ]
         }
     }
+
+    pub fn update_fence(&self, fence: &FenceRef) {
+        unsafe { msg_send![self, updateFence: fence] }
+    }
+
+    pub fn wait_for_fence(&self, fence: &FenceRef) {
+        unsafe { msg_send![self, waitForFence: fence] }
+    }
 }
 
 pub enum MTLComputeCommandEncoder {}
@@ -997,6 +1023,14 @@ impl ComputeCommandEncoderRef {
 
     pub fn use_heap(&self, heap: &HeapRef) {
         unsafe { msg_send![self, useHeap: heap] }
+    }
+
+    pub fn update_fence(&self, fence: &FenceRef) {
+        unsafe { msg_send![self, updateFence: fence] }
+    }
+
+    pub fn wait_for_fence(&self, fence: &FenceRef) {
+        unsafe { msg_send![self, waitForFence: fence] }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,6 +414,7 @@ mod pipeline;
 mod renderpass;
 mod resource;
 mod sampler;
+mod sync;
 mod texture;
 mod types;
 mod vertexdescriptor;
@@ -441,6 +442,7 @@ pub use {
     texture::*,
     types::*,
     vertexdescriptor::*,
+    sync::*,
 };
 
 #[inline]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -95,6 +95,20 @@ impl SharedEventListener {
     }
 }
 
+pub enum MTLFence {}
+
+foreign_obj_type! {
+    type CType = MTLFence;
+    pub struct Fence;
+    pub struct FenceRef;
+}
+
+#[repr(u32)]
+pub enum MTLRenderStages {
+    MTLRenderStageVertex = 0,
+    MTLRenderStageFragment = 1,
+}
+
 const BLOCK_HAS_COPY_DISPOSE: i32 = 0x02000000;
 const BLOCK_HAS_SIGNATURE: i32 = 0x40000000;
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,119 @@
+// Copyright 2016 GFX developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use super::*;
+use block::{Block, RcBlock};
+use std::mem;
+
+type MTLSharedEventNotificationBlock<'a> = RcBlock<(&'a SharedEventRef, u64), ()>;
+
+pub enum MTLEvent {}
+
+foreign_obj_type! {
+    type CType = MTLEvent;
+    pub struct Event;
+    pub struct EventRef;
+}
+
+impl EventRef {
+    pub fn device(&self) -> &DeviceRef {
+        unsafe { msg_send![self, device] }
+    }
+}
+
+pub enum MTLSharedEvent {}
+
+foreign_obj_type! {
+    type CType = MTLSharedEvent;
+    pub struct SharedEvent;
+    pub struct SharedEventRef;
+    type ParentType = EventRef;
+}
+
+impl SharedEventRef {
+    pub fn signaled_value(&self) -> u64 {
+        unsafe { msg_send![self, signaledValue] }
+    }
+
+    pub fn set_signaled_value(&self, new_value: u64) {
+        unsafe { msg_send![self, setSignaledValue: new_value] }
+    }
+
+    pub fn notify(
+        &self,
+        listener: &SharedEventListenerRef,
+        value: u64,
+        block: MTLSharedEventNotificationBlock,
+    ) {
+        unsafe {
+            // If the block doesn't have a signature, this segfaults.
+            // Taken from https://github.com/servo/pathfinder/blob/master/metal/src/lib.rs#L2322
+            let block = mem::transmute::<
+                MTLSharedEventNotificationBlock,
+                *mut BlockBase<(&SharedEventRef, u64), ()>,
+            >(block);
+            (*block).flags |= BLOCK_HAS_SIGNATURE | BLOCK_HAS_COPY_DISPOSE;
+            (*block).extra = &BLOCK_EXTRA;
+            let () = msg_send![self, notifyListener:listener atValue:value block:block];
+            mem::forget(block);
+        }
+
+        extern "C" fn dtor(_: *mut BlockBase<(&SharedEventRef, u64), ()>) {}
+
+        static mut SIGNATURE: &[u8] = b"v16@?0Q8\0";
+        static mut SIGNATURE_PTR: *const i8 = unsafe { &SIGNATURE[0] as *const u8 as *const i8 };
+        static mut BLOCK_EXTRA: BlockExtra<(&SharedEventRef, u64), ()> = BlockExtra {
+            unknown0: 0 as *mut i32,
+            unknown1: 0 as *mut i32,
+            unknown2: 0 as *mut i32,
+            dtor,
+            signature: unsafe { &SIGNATURE_PTR },
+        };
+    }
+}
+
+pub enum MTLSharedEventListener {}
+
+foreign_obj_type! {
+    type CType = MTLSharedEventListener;
+    pub struct SharedEventListener;
+    pub struct SharedEventListenerRef;
+}
+
+impl SharedEventListener {
+    pub unsafe fn from_dispatch_queue(queue: dispatch_queue_t) -> Self {
+        let listener: SharedEventListener = msg_send![class!(MTLSharedEventListener), alloc];
+        let ptr: *mut Object = msg_send![listener.as_ref(), initWithDispatchQueue: queue];
+        if ptr.is_null() {
+            panic!("[MTLSharedEventListener alloc] initWithDispatchQueue failed");
+        }
+        listener
+    }
+}
+
+const BLOCK_HAS_COPY_DISPOSE: i32 = 0x02000000;
+const BLOCK_HAS_SIGNATURE: i32 = 0x40000000;
+
+#[repr(C)]
+struct BlockBase<A, R> {
+    isa: *const std::ffi::c_void,                             // 0x00
+    flags: i32,                                               // 0x08
+    _reserved: i32,                                           // 0x0c
+    invoke: unsafe extern "C" fn(*mut Block<A, R>, ...) -> R, // 0x10
+    extra: *const BlockExtra<A, R>,                           // 0x18
+}
+
+type BlockExtraDtor<A, R> = extern "C" fn(*mut BlockBase<A, R>);
+
+#[repr(C)]
+struct BlockExtra<A, R> {
+    unknown0: *mut i32,          // 0x00
+    unknown1: *mut i32,          // 0x08
+    unknown2: *mut i32,          // 0x10
+    dtor: BlockExtraDtor<A, R>,  // 0x18
+    signature: *const *const i8, // 0x20
+}


### PR DESCRIPTION
This PR adds Metal's sync primitives - Event, SharedEvent, Fence.
`SharedEvent.notify` stuff is a bit messy, but I couldn't find a better way.

ref: https://github.com/gfx-rs/metal-rs/issues/178