### PR TITLE
Use stable build status for bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,4 @@
-status = [ "Build" ]
+status = [ "build (stable)" ]
 
 # As of May 2020 we can expect CI to take roughly 3 minutes based on
 # Based on https://github.com/chinedufn/metal-rs/actions/runs/94020785


### PR DESCRIPTION
I think the `Build` status in bors should be `build (stable)` (optionally `build (nightly)` too) to match the status names reported under the `ci` workflow in GitHub Actions.

This change uses the stable build status only, so PR merges aren't blocked if nightly builds fail.