### PR TITLE
Add DeviceRef::{has_unified_memory, recommended_max_working_set_size, max_tranfer_rate}

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1492,6 +1492,24 @@ impl DeviceRef {
         unsafe { msg_send![self, locationNumber] }
     }
 
+    pub fn has_unified_memory(&self) -> bool {
+        unsafe {
+            match msg_send![self, hasUnifiedMemory] {
+                YES => true,
+                NO => false,
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    pub fn recommended_max_working_set_size(&self) -> u64 {
+        unsafe { msg_send![self, recommendedMaxWorkingSetSize] }
+    }
+
+    pub fn max_transfer_rate(&self) -> u64 {
+        unsafe { msg_send![self, maxTransferRate] }
+    }
+
     pub fn supports_feature_set(&self, feature: MTLFeatureSet) -> bool {
         unsafe {
             match msg_send![self, supportsFeatureSet: feature] {


### PR DESCRIPTION
Adds the following APIs:

- https://developer.apple.com/documentation/metal/mtldevice/3229025-hasunifiedmemory
- https://developer.apple.com/documentation/metal/mtldevice/2369280-recommendedmaxworkingsetsize
- https://developer.apple.com/documentation/metal/mtldevice/3114007-maxtransferrate