### PR TITLE
window example: Fix rendering on hdpi screens

### DIFF
--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -92,6 +92,8 @@ fn main() {
         .with_title("Metal Window Example".to_string())
         .build(&events_loop)
         .unwrap();
+    
+    let mut physical_size = size.to_physical::<u32>(window.scale_factor());
 
     let device = Device::system_default().expect("no device found");
 
@@ -170,6 +172,9 @@ fn main() {
                     WindowEvent::Resized(size) => {
                         layer.set_drawable_size(CGSize::new(size.width as f64, size.height as f64));
                     }
+                    WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
+                        physical_size = *new_inner_size;
+                    }
                     _ => (),
                 },
                 Event::MainEventsCleared => {
@@ -238,8 +243,8 @@ fn main() {
                     encoder.set_scissor_rect(MTLScissorRect {
                         x: 0,
                         y: 0,
-                        width: size.width as _,
-                        height: size.height as _,
+                        width: physical_size.width as _,
+                        height: physical_size.height as _,
                     });
 
                     encoder.set_render_pipeline_state(&triangle_pipeline_state);

--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -92,8 +92,6 @@ fn main() {
         .with_title("Metal Window Example".to_string())
         .build(&events_loop)
         .unwrap();
-    
-    let mut physical_size = size.to_physical::<u32>(window.scale_factor());
 
     let device = Device::system_default().expect("no device found");
 
@@ -172,9 +170,6 @@ fn main() {
                     WindowEvent::Resized(size) => {
                         layer.set_drawable_size(CGSize::new(size.width as f64, size.height as f64));
                     }
-                    WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
-                        physical_size = *new_inner_size;
-                    }
                     _ => (),
                 },
                 Event::MainEventsCleared => {
@@ -240,6 +235,7 @@ fn main() {
                         4,
                         1,
                     );
+                    let physical_size = window.inner_size();
                     encoder.set_scissor_rect(MTLScissorRect {
                         x: 0,
                         y: 0,


### PR DESCRIPTION
Without this PR:

<img width="822" alt="Screen Shot 2021-01-11 at 23 47 10" src="https://user-images.githubusercontent.com/1473433/104284782-a47ddd00-54c3-11eb-8b10-3574701a586a.png">


After this PR:

<img width="814" alt="Screen Shot 2021-01-11 at 23 47 48" src="https://user-images.githubusercontent.com/1473433/104284768-9e87fc00-54c3-11eb-9529-780756b14f4e.png">

I haven't tested the change of scale factor, but it looks reasonable :)