### PR TITLE
Prevent SIGSEGV when returning errors from new_library_with_source

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1688,7 +1688,6 @@ impl DeviceRef {
                 let compile_error: *const std::os::raw::c_char = msg_send![desc, UTF8String];
                 let message = CStr::from_ptr(compile_error).to_string_lossy().into_owned();
                 if library.is_null() {
-                    let () = msg_send![err, release];
                     return Err(message);
                 } else {
                     warn!("Shader warnings: {}", message);


### PR DESCRIPTION
This call SIGSEGVs on my system (10.15.7). Why? And will this leak memory? I have no idea.