### PR TITLE
Prevent SIGSEGV when returning errors from new_library_with_source 2

### DIFF
--- a/examples/error-sigsegv/main.rs
+++ b/examples/error-sigsegv/main.rs
@@ -8,4 +8,5 @@ fn main() {
     let library = device.new_library_with_source(shader_source, &CompileOptions::new());
     eprintln!("{}", library.is_ok());
   });
+  eprintln!("the autorelease pool does not crash");
 }

--- a/examples/error-sigsegv/main.rs
+++ b/examples/error-sigsegv/main.rs
@@ -1,0 +1,11 @@
+use metal::*;
+use objc::rc::autoreleasepool;
+
+fn main() {
+  let device = Device::system_default().expect("no device found");
+  let shader_source = "function (";
+  autoreleasepool(|| {
+    let library = device.new_library_with_source(shader_source, &CompileOptions::new());
+    eprintln!("{}", library.is_ok());
+  });
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -1688,6 +1688,7 @@ impl DeviceRef {
                 let compile_error: *const std::os::raw::c_char = msg_send![desc, UTF8String];
                 let message = CStr::from_ptr(compile_error).to_string_lossy().into_owned();
                 if library.is_null() {
+                    let () = msg_send![err, release];
                     return Err(message);
                 } else {
                     warn!("Shader warnings: {}", message);

--- a/src/device.rs
+++ b/src/device.rs
@@ -1688,7 +1688,6 @@ impl DeviceRef {
                 let compile_error: *const std::os::raw::c_char = msg_send![desc, UTF8String];
                 let message = CStr::from_ptr(compile_error).to_string_lossy().into_owned();
                 if library.is_null() {
-                    let () = msg_send![err, release];
                     return Err(message);
                 } else {
                     warn!("Shader warnings: {}", message);


### PR DESCRIPTION
Ok this is not cleaned up, but directionally I think the way to go. I think the NSError that gets created inside `newLibraryWithSource:source` is autoreleased. So to prevent other wrapping autoreleasepool code from seg faulting we always use autoreleasepool.

While I'm here, I have 1 more problem with this API:

- Warning is just printed - what if I want to use it? It would be better to return the warning along with the library.