### PR TITLE
Use &FenceRef instead of FenceRef in RenderCommandEncoder

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -681,7 +681,7 @@ impl RenderCommandEncoderRef {
         unsafe { msg_send![self, useHeap: heap] }
     }
 
-    pub fn update_fence(&self, fence: FenceRef, after_stages: MTLRenderStages) {
+    pub fn update_fence(&self, fence: &FenceRef, after_stages: MTLRenderStages) {
         unsafe {
             msg_send![self,
                 updateFence: fence
@@ -690,7 +690,7 @@ impl RenderCommandEncoderRef {
         }
     }
 
-    pub fn wait_for_fence(&self, fence: FenceRef, before_stages: MTLRenderStages) {
+    pub fn wait_for_fence(&self, fence: &FenceRef, before_stages: MTLRenderStages) {
         unsafe {
             msg_send![self,
                 waitForFence: fence


### PR DESCRIPTION
As I understand it all Ref objects need to use &s. FYI this change is somewhat blind because my metal backend isn't bootstrapped enough to properly test it yet, so feel free to sit on it until I can :)