### PR TITLE
Finish up the implementation of Binary Archives

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1799,10 +1799,10 @@ impl DeviceRef {
     pub fn new_binary_archive_with_descriptor(
         &self,
         descriptor: &BinaryArchiveDescriptorRef,
-    ) -> Result<(), String> {
+    ) -> Result<BinaryArchive, String> {
         unsafe {
             let mut err: *mut Object = ptr::null_mut();
-            let _r: () = msg_send![self, newBinaryArchiveWithDescriptor:descriptor
+            let binary_archive: *mut MTLBinaryArchive = msg_send![self, newBinaryArchiveWithDescriptor:descriptor
                                                      error:&mut err];
             if !err.is_null() {
                 // TODO: copy pasta
@@ -1811,7 +1811,7 @@ impl DeviceRef {
                 let message = CStr::from_ptr(c_msg).to_string_lossy().into_owned();
                 Err(message)
             } else {
-                Ok(())
+                Ok(BinaryArchive::from_ptr(binary_archive))
             }
         }
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -537,6 +537,14 @@ impl MTLFeatureSet {
         }
     }
 
+    pub fn supports_binary_archive(&self) -> bool {
+        match self.os() {
+            OS::iOS => self.gpu_family() >= 3,
+            OS::tvOS => self.gpu_family() >= 3,
+            OS::macOS => self.gpu_family() >= 1,
+        }
+    }
+
     pub fn max_vertex_attributes(&self) -> u32 {
         31
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1844,6 +1844,27 @@ impl DeviceRef {
         }
     }
 
+    /// Useful for debugging binary archives.
+    pub fn new_render_pipeline_state_with_fail_on_binary_archive_miss(
+        &self,
+        descriptor: &RenderPipelineDescriptorRef,
+    ) -> Result<RenderPipelineState, String> {
+        unsafe {
+            let pipeline_options = MTLPipelineOption::FailOnBinaryArchiveMiss;
+
+            let reflection: *mut MTLRenderPipelineReflection = std::ptr::null_mut();
+
+            let pipeline_state: *mut MTLRenderPipelineState = try_objc! { err =>
+                msg_send![self, newRenderPipelineStateWithDescriptor:descriptor
+                                                             options:pipeline_options
+                                                          reflection:reflection
+                                                               error:&mut err]
+            };
+
+            Ok(RenderPipelineState::from_ptr(pipeline_state))
+        }
+    }
+
     pub fn new_render_pipeline_state(
         &self,
         descriptor: &RenderPipelineDescriptorRef,

--- a/src/pipeline/compute.rs
+++ b/src/pipeline/compute.rs
@@ -235,6 +235,7 @@ impl ComputePipelineDescriptorRef {
         }
     }
 
+    /// API_AVAILABLE(macos(11.0), ios(14.0));
     /// Marshal from Rust slice
     pub fn set_binary_archives(&self, archives: &[&BinaryArchiveRef]) {
         let ns_array = Array::<BinaryArchive>::from_slice(archives);

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -393,8 +393,28 @@ impl RenderPipelineDescriptorRef {
 
     // TODO: tesselation stuff
 
-    // TODO: binaryArchives
-    // @property (readwrite, nullable, nonatomic, copy) NSArray<id<MTLBinaryArchive>> *binaryArchives API_AVAILABLE(macos(11.0), ios(14.0));
+    /// API_AVAILABLE(macos(11.0), ios(14.0));
+    /// Marshal to Rust Vec
+    pub fn binary_archives(&self) -> Vec<BinaryArchive> {
+        unsafe {
+            let archives: *mut Object = msg_send![self, binaryArchives];
+            let count: NSUInteger = msg_send![archives, count];
+            let ret = (0..count)
+                .map(|i| {
+                    let a = msg_send![archives, objectAtIndex: i];
+                    BinaryArchive::from_ptr(a)
+                })
+                .collect();
+            ret
+        }
+    }
+
+    /// API_AVAILABLE(macos(11.0), ios(14.0));
+    /// Marshal from Rust slice
+    pub fn set_binary_archives(&self, archives: &[&BinaryArchiveRef]) {
+        let ns_array = Array::<BinaryArchive>::from_slice(archives);
+        unsafe { msg_send![self, setBinaryArchives: ns_array] }
+    }
 
     pub fn reset(&self) {
         unsafe { msg_send![self, reset] }


### PR DESCRIPTION
As mentioned in https://github.com/gfx-rs/gfx/issues/3716#issuecomment-813698647, we can use [`MTLBinaryArchive`](https://developer.apple.com/documentation/metal/mtlbinaryarchive)s to cache pipelines to disk. This feature was really not clear to me, and seems to be best documented in the WWDC 2020 video [Build GPU Binaries with Metal](https://developer.apple.com/videos/play/wwdc2020/10615/).

Binary Archives were partially implemented, but could not be used so this PR adds that functionality. I modified the circle example to use one but it's possible that making a new example would make more sense. I've tested that the binary archive is indeed written to with the write format, ~~but I've had some trouble creating a pipeline with `MTLPipelineOption::FailOnBinaryArchiveMiss` to check that they're loaded okay~~.