### PR TITLE
Add initial HDR support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,6 +430,28 @@ impl MetalLayerRef {
     pub fn set_opaque(&self, opaque: bool) {
         unsafe { msg_send![self, setOpaque: opaque] }
     }
+
+    pub fn wants_extended_dynamic_range_content(&self) -> bool {
+        unsafe {
+            match msg_send![self, wantsExtendedDynamicRangeContent] {
+                YES => true,
+                NO => false,
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    pub fn set_wants_extended_dynamic_range_content(
+        &self,
+        wants_extended_dynamic_range_content: bool,
+    ) {
+        unsafe {
+            msg_send![
+                self,
+                setWantsExtendedDynamicRangeContent: wants_extended_dynamic_range_content
+            ]
+        }
+    }
 }
 
 mod argument;


### PR DESCRIPTION
This allows rendering HDR content out to display by setting `wantsExtendedDynamicRangeContent`. Tested to work with gfx-hal & wgpu when using `Rgba16Float` swapchain formats. There is more work to be done when it comes to setting [EDR metadata](https://developer.apple.com/documentation/quartzcore/cametallayer/3182052-edrmetadata), but I wanted to get this small change out first.