### PR TITLE
Replace cocoa-foundation dependency to core-graphics-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ private = []
 mps = []
 
 [dependencies]
-cocoa-foundation = "0.1"
+core-graphics-types = "0.1"
 bitflags = "1"
 log = "0.4"
 block = "0.1.6"

--- a/examples/caps/main.rs
+++ b/examples/caps/main.rs
@@ -25,7 +25,7 @@ fn main() {
         println!("Headless: {:?}", device.is_headless());
         println!("D24S8: {:?}", device.d24_s8_supported());
     }
-    println!("maxBufferLength: {} Mb", device.max_buffer_length()>>20);
+    println!("maxBufferLength: {} Mb", device.max_buffer_length() >> 20);
     println!(
         "Indirect argument buffer: {:?}",
         device.argument_buffers_support()

--- a/examples/circle/main.rs
+++ b/examples/circle/main.rs
@@ -1,12 +1,13 @@
 use metal::*;
 
-use winit::platform::macos::WindowExtMacOS;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
+    platform::macos::WindowExtMacOS,
 };
 
 use cocoa::{appkit::NSView, base::id as cocoa_id};
+use core_graphics_types::geometry::CGSize;
 
 use objc::{rc::autoreleasepool, runtime::YES};
 

--- a/examples/shader-dylib/main.rs
+++ b/examples/shader-dylib/main.rs
@@ -1,14 +1,16 @@
 use cocoa::{appkit::NSView, base::id as cocoa_id};
+use core_graphics_types::geometry::CGSize;
 
 use metal::*;
 use objc::{rc::autoreleasepool, runtime::YES};
-use std::mem;
-use winit::platform::macos::WindowExtMacOS;
 
 use winit::{
     event::{Event, WindowEvent},
     event_loop::ControlFlow,
+    platform::macos::WindowExtMacOS,
 };
+
+use std::mem;
 
 struct App {
     pub device: Device,

--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -8,6 +8,7 @@
 extern crate objc;
 
 use cocoa::{appkit::NSView, base::id as cocoa_id};
+use core_graphics_types::geometry::CGSize;
 
 use metal::*;
 use objc::{rc::autoreleasepool, runtime::YES};

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -5,9 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::{Array, MTLTextureType};
-
-use cocoa_foundation::foundation::NSUInteger;
+use super::{Array, MTLTextureType, NSUInteger};
 use objc::runtime::{NO, YES};
 
 #[repr(u64)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -1706,7 +1706,6 @@ impl DeviceRef {
             let library: *mut MTLLibrary = msg_send![self, newLibraryWithSource:source
                                                                         options:options
                                                                           error:&mut err];
-            let () = msg_send![source, release];
             if !err.is_null() {
                 let desc: *mut Object = msg_send![err, localizedDescription];
                 let compile_error: *const c_char = msg_send![desc, UTF8String];
@@ -1730,9 +1729,6 @@ impl DeviceRef {
                 msg_send![self, newLibraryWithFile:filename.as_ref()
                                              error:&mut err]
             };
-
-            let () = msg_send![filename, release];
-
             Ok(Library::from_ptr(library))
         }
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -11,12 +11,7 @@ use block::{Block, ConcreteBlock};
 use foreign_types::ForeignType;
 use objc::runtime::{Object, NO, YES};
 
-use std::{
-    ffi::CStr,
-    os::raw::c_char,
-    path::Path,
-    ptr,
-};
+use std::{ffi::CStr, os::raw::c_char, path::Path, ptr};
 
 #[allow(non_camel_case_types)]
 #[repr(u64)]
@@ -1705,7 +1700,6 @@ impl DeviceRef {
         src: &str,
         options: &CompileOptionsRef,
     ) -> Result<Library, String> {
-
         let source = nsstring_from_str(src);
         unsafe {
             let mut err: *mut Object = ptr::null_mut();

--- a/src/device.rs
+++ b/src/device.rs
@@ -5,18 +5,18 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use super::*;
+
 use block::{Block, ConcreteBlock};
-use cocoa_foundation::base::id;
-use cocoa_foundation::foundation::NSUInteger;
 use foreign_types::ForeignType;
 use objc::runtime::{Object, NO, YES};
 
-use super::*;
-
-use std::ffi::CStr;
-use std::os::raw::c_char;
-use std::path::Path;
-use std::ptr;
+use std::{
+    ffi::CStr,
+    os::raw::c_char,
+    path::Path,
+    ptr,
+};
 
 #[allow(non_camel_case_types)]
 #[repr(u64)]
@@ -1421,9 +1421,9 @@ extern "C" {
 }
 
 #[allow(non_camel_case_types)]
-type dispatch_data_t = id;
+type dispatch_data_t = *mut Object;
 #[allow(non_camel_case_types)]
-pub type dispatch_queue_t = id;
+pub type dispatch_queue_t = *mut Object;
 #[allow(non_camel_case_types)]
 type dispatch_block_t = *const Block<(), ()>;
 
@@ -1705,11 +1705,9 @@ impl DeviceRef {
         src: &str,
         options: &CompileOptionsRef,
     ) -> Result<Library, String> {
-        use cocoa_foundation::base::nil as cocoa_nil;
-        use cocoa_foundation::foundation::NSString as cocoa_NSString;
 
+        let source = nsstring_from_str(src);
         unsafe {
-            let source = cocoa_NSString::alloc(cocoa_nil).init_str(src);
             let mut err: *mut Object = ptr::null_mut();
             let library: *mut MTLLibrary = msg_send![self, newLibraryWithSource:source
                                                                         options:options
@@ -1732,13 +1730,8 @@ impl DeviceRef {
     }
 
     pub fn new_library_with_file<P: AsRef<Path>>(&self, file: P) -> Result<Library, String> {
-        use cocoa_foundation::base::nil as cocoa_nil;
-        use cocoa_foundation::foundation::NSString as cocoa_NSString;
-
+        let filename = nsstring_from_str(file.as_ref().to_string_lossy().as_ref());
         unsafe {
-            let filename =
-                cocoa_NSString::alloc(cocoa_nil).init_str(file.as_ref().to_string_lossy().as_ref());
-
             let library: *mut MTLLibrary = try_objc! { err =>
                 msg_send![self, newLibraryWithFile:filename.as_ref()
                                              error:&mut err]

--- a/src/drawable.rs
+++ b/src/drawable.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use cocoa_foundation::foundation::NSUInteger;
+use super::NSUInteger;
 
 pub enum MTLDrawable {}
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -7,8 +7,6 @@
 
 use super::*;
 
-use cocoa_foundation::foundation::{NSInteger, NSUInteger};
-
 use std::ops::Range;
 
 #[repr(u64)]

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -7,8 +7,6 @@
 
 use super::*;
 
-use cocoa_foundation::foundation::NSUInteger;
-
 /// Only available on macos(10.15), ios(13.0)
 #[repr(u64)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/src/indirect_encoder.rs
+++ b/src/indirect_encoder.rs
@@ -1,7 +1,5 @@
 use super::*;
 
-use cocoa_foundation::foundation::NSUInteger;
-
 bitflags! {
     #[allow(non_upper_case_globals)]
     pub struct MTLIndirectCommandType: NSUInteger {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,33 +17,27 @@ extern crate objc;
 #[macro_use]
 extern crate foreign_types;
 
-use std::borrow::{Borrow, ToOwned};
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::Deref;
-use std::os::raw::c_void;
+use std::{
+    borrow::{Borrow, ToOwned},
+    marker::PhantomData,
+    mem,
+    os::raw::c_void,
+    ops::Deref,
+};
 
-use cocoa_foundation::foundation::NSUInteger;
+use core_graphics_types::{base::CGFloat, geometry::CGSize};
 use foreign_types::ForeignType;
 use objc::runtime::{Object, NO, YES};
 
+
 #[cfg(target_pointer_width = "64")]
-pub type CGFloat = f64;
+pub type NSInteger = i64;
 #[cfg(not(target_pointer_width = "64"))]
-pub type CGFloat = f32;
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub struct CGSize {
-    pub width: CGFloat,
-    pub height: CGFloat,
-}
-
-impl CGSize {
-    pub fn new(width: f64, height: f64) -> Self {
-        CGSize { width, height }
-    }
-}
+pub type NSInteger = i32;
+#[cfg(target_pointer_width = "64")]
+pub type NSUInteger = u64;
+#[cfg(target_pointer_width = "32")]
+pub type NSUInteger = u32;
 
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,14 +21,13 @@ use std::{
     borrow::{Borrow, ToOwned},
     marker::PhantomData,
     mem,
-    os::raw::c_void,
     ops::Deref,
+    os::raw::c_void,
 };
 
 use core_graphics_types::{base::CGFloat, geometry::CGSize};
 use foreign_types::ForeignType;
 use objc::runtime::{Object, NO, YES};
-
 
 #[cfg(target_pointer_width = "64")]
 pub type NSInteger = i64;

--- a/src/library.rs
+++ b/src/library.rs
@@ -7,7 +7,6 @@
 
 use super::*;
 
-use cocoa_foundation::foundation::NSUInteger;
 use foreign_types::ForeignType;
 use objc::runtime::{Object, BOOL, NO, YES};
 

--- a/src/pipeline/compute.rs
+++ b/src/pipeline/compute.rs
@@ -7,7 +7,6 @@
 
 use super::*;
 
-use cocoa_foundation::foundation::NSUInteger;
 use objc::runtime::{NO, YES};
 
 #[repr(u64)]

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -7,7 +7,6 @@
 
 use super::*;
 
-use cocoa_foundation::foundation::NSUInteger;
 use objc::runtime::{NO, YES};
 
 #[repr(u64)]

--- a/src/renderpass.rs
+++ b/src/renderpass.rs
@@ -7,8 +7,6 @@
 
 use super::*;
 
-use cocoa_foundation::foundation::NSUInteger;
-
 #[repr(u64)]
 #[derive(Copy, Clone, Debug)]
 pub enum MTLLoadAction {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -5,8 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use super::{DeviceRef, HeapRef};
-use cocoa_foundation::foundation::NSUInteger;
+use super::{DeviceRef, HeapRef, NSUInteger};
 use objc::runtime::{NO, YES};
 
 #[repr(u64)]

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -5,11 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use super::{
-    NSUInteger,
-    depthstencil::MTLCompareFunction,
-    DeviceRef,
-};
+use super::{depthstencil::MTLCompareFunction, DeviceRef, NSUInteger};
 
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -5,10 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use cocoa_foundation::foundation::NSUInteger;
-
-use crate::depthstencil::MTLCompareFunction;
-use crate::DeviceRef;
+use super::{
+    NSUInteger,
+    depthstencil::MTLCompareFunction,
+    DeviceRef,
+};
 
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -7,7 +7,6 @@
 
 use super::*;
 
-use cocoa_foundation::foundation::NSUInteger;
 use objc::runtime::{NO, YES};
 
 #[repr(u64)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use cocoa_foundation::foundation::NSUInteger;
+use super::NSUInteger;
 use std::default::Default;
 
 #[repr(C)]

--- a/src/vertexdescriptor.rs
+++ b/src/vertexdescriptor.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use cocoa_foundation::foundation::NSUInteger;
+use super::NSUInteger;
 
 #[repr(u64)]
 #[allow(non_camel_case_types)]


### PR DESCRIPTION
`core-graphics-types` is a smaller dependency, which I think we can accept to depend on across the stack.
`cocoa-foundation` doesn't appear to be necessary.