### PR TITLE
add new_buffer_with_bytes_no_copy

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1916,6 +1916,21 @@ impl DeviceRef {
         }
     }
 
+    pub fn new_buffer_with_bytes_no_copy(
+        &self,
+        bytes: *const std::ffi::c_void,
+        length: NSUInteger,
+        options: MTLResourceOptions,
+        deallocator: Option<&Block<(*const std::ffi::c_void, NSUInteger), ()>>,
+    ) -> Buffer {
+        unsafe {
+            msg_send![self, newBufferWithBytesNoCopy:bytes
+                length:length
+                options:options
+                deallocator:deallocator]
+        }
+    }
+
     pub fn new_buffer_with_data(
         &self,
         bytes: *const std::ffi::c_void,


### PR DESCRIPTION
This adds support for creating buffers without copies via `newBufferWithBytesNoCopy:length:options:deallocator:`.

https://developer.apple.com/documentation/metal/mtldevice/1433382-newbufferwithbytesnocopy?language=objc