### PR TITLE
make CGFloat and CGSize public again

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use std::{
     os::raw::c_void,
 };
 
-use core_graphics_types::{base::CGFloat, geometry::CGSize};
+pub use core_graphics_types::{base::CGFloat, geometry::CGSize};
 use foreign_types::ForeignType;
 use objc::runtime::{Object, NO, YES};
 


### PR DESCRIPTION
In https://github.com/gfx-rs/metal-rs/pull/214, `CGFloat` and `CGSize` went from being public to private, which breaks compatibility with the gfx backend. This makes them public again.