### PR TITLE
Update `winit` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ features = ["objc_exception"]
 [dev-dependencies]
 cocoa = "0.24.0"
 cty = "0.2.1"
-winit = "0.22"
+winit = "0.24"
 sema = "0.1.4"
 png = "0.16"
 


### PR DESCRIPTION
Update `winit` dependency to fix `expected bool, found integer` error at `window.setFrame_display_(current_rect, 0)` and `expected bool, found i8` at `(marked_text.length() > 0) as i8`. rustc 1.56.1 at Apple M1 8/8 MacBook Air for `window example`