### PR TITLE
Add support for getting/setting colorspace, add missing GPU families

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ mps = []
 
 [dependencies]
 core-graphics-types = "0.1"
+core-graphics = "0.22.3"
 bitflags = "1"
 log = "0.4"
 block = "0.1.6"

--- a/src/device.rs
+++ b/src/device.rs
@@ -62,6 +62,8 @@ pub enum MTLGPUFamily {
     Apple4 = 1004,
     Apple5 = 1005,
     Apple6 = 1006,
+    Apple7 = 1007,
+    Apple8 = 1008,
     Mac1 = 2001,
     Mac2 = 2002,
     MacCatalyst1 = 4001,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ use std::{
     os::raw::c_void,
 };
 
+use core_graphics::color_space::CGColorSpaceRef;
 use core_graphics_types::{base::CGFloat, geometry::CGSize};
 use foreign_types::ForeignType;
 use objc::runtime::{Object, NO, YES};
@@ -444,6 +445,14 @@ impl MetalLayerRef {
                 setWantsExtendedDynamicRangeContent: wants_extended_dynamic_range_content
             ]
         }
+    }
+
+    pub fn colorspace(&self) -> &CGColorSpaceRef {
+        unsafe { msg_send![self, colorspace] }
+    }
+
+    pub fn set_colorspace(&self, colorspace: &CGColorSpaceRef) {
+        unsafe { msg_send![self, setColorspace: colorspace] }
     }
 }
 


### PR DESCRIPTION
Is adding core-graphics as a dependency ok? Is there an alternative?