### PR TITLE
Reflection fixes

### DIFF
--- a/examples/reflection/main.rs
+++ b/examples/reflection/main.rs
@@ -60,16 +60,16 @@ fn main() {
 
         println!("{:?}", desc);
 
-        #[cfg(features = "private")]
-        let _reflection = unsafe {
-            RenderPipelineReflection::new(
-                desc.serialize_vertex_data(),
-                desc.serialize_fragment_data(),
-                vertex_desc.serialize_descriptor(),
-                &device,
-                0x8,
-                0x0,
-            )
-        };
+        let reflect_options = MTLPipelineOption::ArgumentInfo | MTLPipelineOption::BufferTypeInfo;
+        let (_, reflection) = device
+            .new_render_pipeline_state_with_reflection(&desc, reflect_options)
+            .unwrap();
+
+        println!("Vertex arguments: ");
+        let vertex_arguments = reflection.vertex_arguments();
+        for index in 0..vertex_arguments.count() {
+            let argument = vertex_arguments.object_at(index).unwrap();
+            println!("{:?}", argument);
+        }
     });
 }

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use super::{Array, MTLTextureType, NSUInteger};
+use super::{MTLTextureType, NSUInteger};
 use objc::runtime::{NO, YES};
 
 #[repr(u64)]
@@ -161,6 +161,24 @@ impl StructMemberRef {
     }
 }
 
+pub enum MTLStructMemberArray {}
+
+foreign_obj_type! {
+    type CType = MTLStructMemberArray;
+    pub struct StructMemberArray;
+    pub struct StructMemberArrayRef;
+}
+
+impl StructMemberArrayRef {
+    pub fn object_at(&self, index: NSUInteger) -> Option<&StructMemberRef> {
+        unsafe { msg_send![self, objectAtIndexedSubscript: index] }
+    }
+
+    pub fn count(&self) -> NSUInteger {
+        unsafe { msg_send![self, count] }
+    }
+}
+
 pub enum MTLStructType {}
 
 foreign_obj_type! {
@@ -170,7 +188,7 @@ foreign_obj_type! {
 }
 
 impl StructTypeRef {
-    pub fn members(&self) -> &Array<StructMember> {
+    pub fn members(&self) -> &StructMemberArrayRef {
         unsafe { msg_send![self, members] }
     }
 

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -193,12 +193,52 @@ impl RenderPipelineReflection {
 }
 
 impl RenderPipelineReflectionRef {
-    pub fn fragment_arguments(&self) -> &Array<Argument> {
+    /// An array of objects that describe the arguments of a fragment function.
+    pub fn fragment_arguments(&self) -> &ArgumentArrayRef {
         unsafe { msg_send![self, fragmentArguments] }
     }
 
-    pub fn vertex_arguments(&self) -> &Array<Argument> {
+    /// An array of objects that describe the arguments of a vertex function.
+    pub fn vertex_arguments(&self) -> &ArgumentArrayRef {
         unsafe { msg_send![self, vertexArguments] }
+    }
+
+    /// An array of objects that describe the arguments of a tile shading function.
+    pub fn tile_arguments(&self) -> &ArgumentArrayRef {
+        unsafe { msg_send![self, tileArguments] }
+    }
+}
+
+pub enum MTLArgumentArray {}
+
+foreign_obj_type! {
+    type CType = MTLArgumentArray;
+    pub struct ArgumentArray;
+    pub struct ArgumentArrayRef;
+}
+
+impl ArgumentArrayRef {
+    pub fn object_at(&self, index: NSUInteger) -> Option<&ArgumentRef> {
+        unsafe { msg_send![self, objectAtIndexedSubscript: index] }
+    }
+
+    pub fn count(&self) -> NSUInteger {
+        unsafe { msg_send![self, count] }
+    }
+}
+
+pub enum MTLComputePipelineReflection {}
+
+foreign_obj_type! {
+    type CType = MTLComputePipelineReflection;
+    pub struct ComputePipelineReflection;
+    pub struct ComputePipelineReflectionRef;
+}
+
+impl ComputePipelineReflectionRef {
+    /// An array of objects that describe the arguments of a compute function.
+    pub fn arguments(&self) -> &ArgumentArrayRef {
+        unsafe { msg_send![self, arguments] }
     }
 }
 


### PR DESCRIPTION
- There is no need to allocate `MTLRenderPipelineReflection` when calling `newRenderPipelineStateWithDescriptor` with reflection.
- Adds array wrappers to iterate over reflection information.
- Removes `new_render_pipeline_state_with_fail_on_binary_archive_miss` (refactored `new_render_pipeline_state_with_reflection` covers it).
- Exposes `MTLPipelineOption`
- Access reflection for compute pipeline.
- Update relevant documentation.

Output from reflection example:
```
Vertex arguments: 
<MTLBufferArgument: 0x6000010980c0>
    Name = vertex_array 
    Type = MTLArgumentTypeBuffer 
    Access = MTLArgumentAccessReadWrite 
    LocationIndex = 0 
    IsActive = 1 
    ArrayLength = 1 
    TypeInfo = 
        DataType = MTLDataTypePointer 
        ElementType = MTLDataTypeStruct 
        ElementTypeDescription = <MTLStructTypeInternal: 0x600003a8df50>
            DataType = MTLDataTypeStruct 
            0 <MTLStructMemberInternal: 0x600001098120>
                Name = position 
                Offset = 0 
                DataType = MTLDataTypeFloat2 
                ArgumentIndex = 0 
                TypeInfo =  nil 
            1 <MTLStructMemberInternal: 0x600001098180>
                Name = color 
                Offset = 16 
                DataType = MTLDataTypeFloat3 
                ArgumentIndex = 0 
                TypeInfo =  nil 
        Access = MTLArgumentAccessReadWrite 
        Alignment = 16 
        DataSize = 32
    Alignment = 16 
    DataSize = 32 
    DataType = MTLDataTypeStruct

Process finished with exit code 0

```