### PR TITLE
Fix incorrect MTLRenderStages constants

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -139,8 +139,8 @@ impl FenceRef {
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLRenderStages {
-    Vertex = 0,
-    Fragment = 1,
+    Vertex = 1,
+    Fragment = 2,
 }
 
 const BLOCK_HAS_COPY_DISPOSE: i32 = 0x02000000;


### PR DESCRIPTION
This potentially fixes synchronization as these constants are passed to APIs like `waitForFence(_ fence: MTLFence, 
           before stages: MTLRenderStages)`

https://developer.apple.com/documentation/metal/mtlrendercommandencoder/1648378-waitforfence

Would appreciate if someone could properly double-check this. I can see from the metal frame capture that this fixed incorrect values for me, and these docs show the constants being used in other bindings. https://docs.microsoft.com/en-us/dotnet/api/metal.mtlrenderstages?view=xamarin-ios-sdk-12 I was not able to find the correct values published by apple. (Maybe their C++ bindings would have them)