### PR TITLE
Add `V2_4` MTLLanguageVersion and `macOS_ReadWriteTextureTier2` feature

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -13,6 +13,7 @@ use objc::runtime::{Object, NO, YES};
 
 use std::{ffi::CStr, os::raw::c_char, path::Path, ptr};
 
+// Available on macOS 10.11+, iOS 8.0+, tvOS 9.0+
 #[allow(non_camel_case_types)]
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -44,12 +45,14 @@ pub enum MTLFeatureSet {
 
     macOS_GPUFamily1_v1 = 10000,
     macOS_GPUFamily1_v2 = 10001,
-    //macOS_ReadWriteTextureTier2 = 10002, TODO: Uncomment when feature tables updated
+    // Available on macOS 10.12+
+    macOS_ReadWriteTextureTier2 = 10002,
     macOS_GPUFamily1_v3 = 10003,
     macOS_GPUFamily1_v4 = 10004,
     macOS_GPUFamily2_v1 = 10005,
 }
 
+// Available on macOS 10.15+, iOS 13.0+
 #[repr(i64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[non_exhaustive]
@@ -133,7 +136,7 @@ impl MTLFeatureSet {
             tvOS_GPUFamily1_v3 | tvOS_GPUFamily2_v1 => 11,
             tvOS_GPUFamily1_v4 | tvOS_GPUFamily2_v2 => 12,
             macOS_GPUFamily1_v1 => 11,
-            macOS_GPUFamily1_v2 => 12,
+            macOS_GPUFamily1_v2 | macOS_ReadWriteTextureTier2 => 12,
             macOS_GPUFamily1_v3 => 13,
             macOS_GPUFamily1_v4 | macOS_GPUFamily2_v1 => 14,
         }
@@ -142,10 +145,20 @@ impl MTLFeatureSet {
     fn gpu_family(&self) -> u32 {
         use MTLFeatureSet::*;
         match self {
-            iOS_GPUFamily1_v1 | iOS_GPUFamily1_v2 | iOS_GPUFamily1_v3 | iOS_GPUFamily1_v4
-            | iOS_GPUFamily1_v5 | tvOS_GPUFamily1_v1 | tvOS_GPUFamily1_v2 | tvOS_GPUFamily1_v3
-            | tvOS_GPUFamily1_v4 | macOS_GPUFamily1_v1 | macOS_GPUFamily1_v2
-            | macOS_GPUFamily1_v3 | macOS_GPUFamily1_v4 => 1,
+            iOS_GPUFamily1_v1
+            | iOS_GPUFamily1_v2
+            | iOS_GPUFamily1_v3
+            | iOS_GPUFamily1_v4
+            | iOS_GPUFamily1_v5
+            | tvOS_GPUFamily1_v1
+            | tvOS_GPUFamily1_v2
+            | tvOS_GPUFamily1_v3
+            | tvOS_GPUFamily1_v4
+            | macOS_GPUFamily1_v1
+            | macOS_GPUFamily1_v2
+            | macOS_ReadWriteTextureTier2
+            | macOS_GPUFamily1_v3
+            | macOS_GPUFamily1_v4 => 1,
             iOS_GPUFamily2_v1 | iOS_GPUFamily2_v2 | iOS_GPUFamily2_v3 | iOS_GPUFamily2_v4
             | iOS_GPUFamily2_v5 | tvOS_GPUFamily2_v1 | tvOS_GPUFamily2_v2 | macOS_GPUFamily2_v1 => {
                 2
@@ -159,9 +172,16 @@ impl MTLFeatureSet {
     fn version(&self) -> u32 {
         use MTLFeatureSet::*;
         match self {
-            iOS_GPUFamily1_v1 | iOS_GPUFamily2_v1 | iOS_GPUFamily3_v1 | iOS_GPUFamily4_v1
-            | iOS_GPUFamily5_v1 | macOS_GPUFamily1_v1 | macOS_GPUFamily2_v1
-            | tvOS_GPUFamily1_v1 | tvOS_GPUFamily2_v1 => 1,
+            iOS_GPUFamily1_v1
+            | iOS_GPUFamily2_v1
+            | iOS_GPUFamily3_v1
+            | iOS_GPUFamily4_v1
+            | iOS_GPUFamily5_v1
+            | macOS_GPUFamily1_v1
+            | macOS_GPUFamily2_v1
+            | macOS_ReadWriteTextureTier2
+            | tvOS_GPUFamily1_v1
+            | tvOS_GPUFamily2_v1 => 1,
             iOS_GPUFamily1_v2 | iOS_GPUFamily2_v2 | iOS_GPUFamily3_v2 | iOS_GPUFamily4_v2
             | macOS_GPUFamily1_v2 | tvOS_GPUFamily1_v2 | tvOS_GPUFamily2_v2 => 2,
             iOS_GPUFamily1_v3 | iOS_GPUFamily2_v3 | iOS_GPUFamily3_v3 | macOS_GPUFamily1_v3

--- a/src/library.rs
+++ b/src/library.rs
@@ -387,8 +387,10 @@ pub enum MTLLanguageVersion {
     V2_0 = 0x20000,
     V2_1 = 0x20001,
     V2_2 = 0x20002,
-    /// Only available on (macos(11.0), ios(14.0))
+    /// available on macOS 11.0+, iOS 14.0+
     V2_3 = 0x20003,
+    /// available on macOS 12.0+, iOS 15.0+
+    V2_4 = 0x20004,
 }
 
 pub enum MTLFunctionConstantValues {}


### PR DESCRIPTION
Trivial commit, `macOS_ReadWriteTextureTier2` feature is needed to fix wgpu's  `read_write_texture_tier` . 

Added two comments above `MTLFeatureSet` and `MTLGPUFamily` because someone confused the relationship between the two.