### PR TITLE
Add `push | pop_debug_group` fn to CommandBuffer

### DIFF
--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -144,4 +144,15 @@ impl CommandBufferRef {
             ]
         }
     }
+
+    pub fn push_debug_group(&self, name: &str) {
+        unsafe {
+            let nslabel = crate::nsstring_from_str(name);
+            msg_send![self, pushDebugGroup: nslabel]
+        }
+    }
+
+    pub fn pop_debug_group(&self) {
+        unsafe { msg_send![self, popDebugGroup] }
+    }
 }


### PR DESCRIPTION
This is needed to fix the wgpu metal backend `push | pop_debug_group` implementation