### PR TITLE
Add inline attribute to deref

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ macro_rules! foreign_obj_type {
         impl ::std::ops::Deref for $ref_ident {
             type Target = $parent_ref;
 
+            #[inline]
             fn deref(&self) -> &$parent_ref {
                 unsafe { &*(self as *const $ref_ident as *const $parent_ref)  }
             }
@@ -255,6 +256,7 @@ where
 {
     type Target = ArrayRef<T>;
 
+    #[inline]
     fn deref(&self) -> &ArrayRef<T> {
         unsafe { mem::transmute(self.as_ptr()) }
     }


### PR DESCRIPTION
While examining the release build assembly, I noticed a branch that precedes any call to an Objective-C parent type method.

For example, `color_attachment.set_texture(Some(texture));`...

```asm
...
Ltmp157:
	mov	x0, x25
	bl	__ZN101_$LT$metal..renderpass..RenderPassColorAttachmentDescriptorRef$u20$as$u20$core..ops..deref..Deref$GT$5deref17h157b1b3f5a4ba402E
Ltmp158:
Ltmp159:
	mov	x1, x26
	bl	__ZN5metal10renderpass33RenderPassAttachmentDescriptorRef11set_texture17he4f575ac4d07711eE
...
__ZN101_$LT$metal..renderpass..RenderPassColorAttachmentDescriptorRef$u20$as$u20$core..ops..deref..Deref$GT$5deref17h157b1b3f5a4ba402E:
	.cfi_startproc
	ret
	.cfi_endproc
```

Seems like an easy improvement without requiring users to commit to LTO.
