### PR TITLE
Use `objc2` instead of `objc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,15 @@ link = []
 [dependencies]
 bitflags = "2"
 log = "0.4"
-block2 = "=0.2.0-alpha.6"
+block2 = "=0.2.0-alpha.7"
 foreign-types = "0.5"
 dispatch = { version = "0.2", optional = true }
 paste = "1"
-objc2 = "=0.3.0-beta.2"
+objc2 = "=0.3.0-beta.4"
+
+[dependencies.icrate]
+version = "0.0.1"
+features = ["Foundation"]
 
 [dev-dependencies]
 cocoa = "0.24.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ link = []
 [dependencies]
 bitflags = "2"
 log = "0.4"
-block2 = "=0.2.0-alpha.8"
+block2 = "0.3.0"
 foreign-types = "0.5"
 dispatch = { version = "0.2", optional = true }
 paste = "1"
-objc2 = "=0.3.0-beta.5"
+objc2 = "0.4.1"
 
 [dependencies.icrate]
-version = "0.0.2"
+version = "0.0.4"
 features = ["Foundation"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,17 +22,15 @@ mps = []
 link = []
 
 [dependencies]
-core-graphics-types = "0.1"
+# Branch: objc2. TODO: Remove this
+core-graphics-types = { git = "https://github.com/madsmtm/core-foundation-rs.git", rev = "7d593d016175755e492a92ef89edca68ac3bd5cd" }
 bitflags = "2"
 log = "0.4"
-block = "0.1.6"
+block2 = "=0.2.0-alpha.6"
 foreign-types = "0.5"
 dispatch = { version = "0.2", optional = true }
 paste = "1"
-
-[dependencies.objc]
-version = "0.2.4"
-features = ["objc_exception"]
+objc2 = "=0.3.0-beta.2"
 
 [dev-dependencies]
 cocoa = "0.24.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ link = []
 [dependencies]
 bitflags = "2"
 log = "0.4"
-block2 = "=0.2.0-alpha.7"
+block2 = "=0.2.0-alpha.8"
 foreign-types = "0.5"
 dispatch = { version = "0.2", optional = true }
 paste = "1"
-objc2 = "=0.3.0-beta.4"
+objc2 = "=0.3.0-beta.5"
 
 [dependencies.icrate]
-version = "0.0.1"
+version = "0.0.2"
 features = ["Foundation"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,6 @@ mps = []
 link = []
 
 [dependencies]
-# Branch: objc2. TODO: Remove this
-core-graphics-types = { git = "https://github.com/madsmtm/core-foundation-rs.git", rev = "7d593d016175755e492a92ef89edca68ac3bd5cd" }
 bitflags = "2"
 log = "0.4"
 block2 = "=0.2.0-alpha.6"

--- a/examples/argument-buffer/main.rs
+++ b/examples/argument-buffer/main.rs
@@ -6,10 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 use metal::*;
-use objc::rc::autoreleasepool;
+use objc2::rc::autoreleasepool;
 
 fn main() {
-    autoreleasepool(|| {
+    autoreleasepool(|_| {
         let device = Device::system_default().expect("no device found");
 
         /*

--- a/examples/bind/main.rs
+++ b/examples/bind/main.rs
@@ -6,10 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 use metal::*;
-use objc::rc::autoreleasepool;
+use objc2::rc::autoreleasepool;
 
 fn main() {
-    autoreleasepool(|| {
+    autoreleasepool(|_| {
         let device = Device::system_default().expect("no device found");
 
         let buffer = device.new_buffer(4, MTLResourceOptions::empty());

--- a/examples/bindless/main.rs
+++ b/examples/bindless/main.rs
@@ -8,7 +8,7 @@
 use metal::*;
 use objc2::rc::autoreleasepool;
 
-const BINDLESS_TEXTURE_COUNT: NSUInteger = 100_000; // ~25Mb
+const BINDLESS_TEXTURE_COUNT: usize = 100_000; // ~25Mb
 
 /// This example demonstrates:
 /// - How to create a heap
@@ -93,7 +93,7 @@ fn main() {
         // Encode textures to the argument buffer.
         textures.iter().enumerate().for_each(|(index, texture)| {
             // Offset encoder to a proper texture slot
-            let offset = index as NSUInteger * encoder.encoded_length();
+            let offset = index * encoder.encoded_length();
             encoder.set_argument_buffer(&argument_buffer, offset);
             encoder.set_texture(0, texture);
         });

--- a/examples/bindless/main.rs
+++ b/examples/bindless/main.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use metal::*;
-use objc::rc::autoreleasepool;
+use objc2::rc::autoreleasepool;
 
 const BINDLESS_TEXTURE_COUNT: NSUInteger = 100_000; // ~25Mb
 
@@ -16,7 +16,7 @@ const BINDLESS_TEXTURE_COUNT: NSUInteger = 100_000; // ~25Mb
 /// - How to create bindless resources via Metal's argument buffers.
 /// - How to bind argument buffer to render encoder
 fn main() {
-    autoreleasepool(|| {
+    autoreleasepool(|_| {
         let device = Device::system_default().expect("no device found");
 
         /*

--- a/examples/circle/main.rs
+++ b/examples/circle/main.rs
@@ -106,7 +106,7 @@ fn main() {
     }
 
     let draw_size = window.inner_size();
-    layer.set_drawable_size(CGSize::new(draw_size.width as f64, draw_size.height as f64));
+    layer.set_drawable_size(draw_size.width as f64, draw_size.height as f64);
 
     let vbuf = {
         let vertex_data = create_vertex_points_for_circle();

--- a/examples/circle/main.rs
+++ b/examples/circle/main.rs
@@ -248,10 +248,10 @@ fn handle_render_pass_sample_buffer_attachment(
     let sample_buffer_attachment_descriptor =
         descriptor.sample_buffer_attachments().object_at(0).unwrap();
     sample_buffer_attachment_descriptor.set_sample_buffer(&counter_sample_buffer);
-    sample_buffer_attachment_descriptor.set_start_of_vertex_sample_index(0 as NSUInteger);
-    sample_buffer_attachment_descriptor.set_end_of_vertex_sample_index(1 as NSUInteger);
-    sample_buffer_attachment_descriptor.set_start_of_fragment_sample_index(2 as NSUInteger);
-    sample_buffer_attachment_descriptor.set_end_of_fragment_sample_index(3 as NSUInteger);
+    sample_buffer_attachment_descriptor.set_start_of_vertex_sample_index(0);
+    sample_buffer_attachment_descriptor.set_end_of_vertex_sample_index(1);
+    sample_buffer_attachment_descriptor.set_start_of_fragment_sample_index(2);
+    sample_buffer_attachment_descriptor.set_end_of_fragment_sample_index(3);
 }
 
 fn handle_render_pass_color_attachment(descriptor: &RenderPassDescriptorRef, texture: &TextureRef) {

--- a/examples/circle/main.rs
+++ b/examples/circle/main.rs
@@ -9,7 +9,8 @@ use winit::{
 use cocoa::{appkit::NSView, base::id as cocoa_id};
 use core_graphics_types::geometry::CGSize;
 
-use objc::{rc::autoreleasepool, runtime::YES};
+use objc2::rc::autoreleasepool;
+use objc2::runtime::Bool;
 
 use std::mem;
 
@@ -101,7 +102,7 @@ fn main() {
 
     unsafe {
         let view = window.ns_view() as cocoa_id;
-        view.setWantsLayer(YES);
+        view.setWantsLayer(Bool::YES.as_raw());
         view.setLayer(mem::transmute(layer.as_ref()));
     }
 
@@ -120,7 +121,7 @@ fn main() {
     };
 
     event_loop.run(move |event, _, control_flow| {
-        autoreleasepool(|| {
+        autoreleasepool(|_| {
             // ControlFlow::Wait pauses the event loop if no events are available to process.
             // This is ideal for non-game applications that only update in response to user
             // input, and uses significantly less power/CPU time than ControlFlow::Poll.

--- a/examples/circle/main.rs
+++ b/examples/circle/main.rs
@@ -299,12 +299,7 @@ fn resolve_samples_into_buffer(
     destination_buffer: &BufferRef,
 ) {
     let blit_encoder = command_buffer.new_blit_command_encoder();
-    blit_encoder.resolve_counters(
-        &counter_sample_buffer,
-        NSRange::new(0, 4),
-        &destination_buffer,
-        0,
-    );
+    blit_encoder.resolve_counters(&counter_sample_buffer, 0..4, &destination_buffer, 0);
     blit_encoder.end_encoding();
 }
 

--- a/examples/circle/main.rs
+++ b/examples/circle/main.rs
@@ -7,7 +7,6 @@ use winit::{
 };
 
 use cocoa::{appkit::NSView, base::id as cocoa_id};
-use core_graphics_types::geometry::CGSize;
 
 use objc2::rc::autoreleasepool;
 use objc2::runtime::Bool;
@@ -53,7 +52,7 @@ fn main() {
     device.sample_timestamps(&mut cpu_start, &mut gpu_start);
     let counter_sample_buffer = create_counter_sample_buffer(&device);
     let destination_buffer = device.new_buffer(
-        (std::mem::size_of::<u64>() * 4 as usize) as u64,
+        std::mem::size_of::<u64>() * 4,
         MTLResourceOptions::StorageModeShared,
     );
     let counter_sampling_point = MTLCounterSamplingPoint::AtStageBoundary;
@@ -115,7 +114,7 @@ fn main() {
 
         device.new_buffer_with_data(
             vertex_data.as_ptr() as *const _,
-            (vertex_data.len() * mem::size_of::<AAPLVertex>()) as u64,
+            vertex_data.len() * mem::size_of::<AAPLVertex>(),
             MTLResourceOptions::CPUCacheModeDefaultCache | MTLResourceOptions::StorageModeManaged,
         )
     };
@@ -302,9 +301,9 @@ fn resolve_samples_into_buffer(
     let blit_encoder = command_buffer.new_blit_command_encoder();
     blit_encoder.resolve_counters(
         &counter_sample_buffer,
-        crate::NSRange::new(0_u64, 4),
+        NSRange::new(0, 4),
         &destination_buffer,
-        0_u64,
+        0,
     );
     blit_encoder.end_encoding();
 }

--- a/examples/compute/compute-argument-buffer.rs
+++ b/examples/compute/compute-argument-buffer.rs
@@ -23,7 +23,7 @@ fn main() {
 
         let buffer = device.new_buffer_with_data(
             unsafe { mem::transmute(data.as_ptr()) },
-            (data.len() * mem::size_of::<u32>()) as u64,
+            data.len() * mem::size_of::<u32>(),
             MTLResourceOptions::CPUCacheModeDefaultCache,
         );
 
@@ -31,7 +31,7 @@ fn main() {
             let data = [0u32];
             device.new_buffer_with_data(
                 unsafe { mem::transmute(data.as_ptr()) },
-                (data.len() * mem::size_of::<u32>()) as u64,
+                data.len() * mem::size_of::<u32>(),
                 MTLResourceOptions::CPUCacheModeDefaultCache,
             )
         };
@@ -77,7 +77,7 @@ fn main() {
         };
 
         let thread_group_size = MTLSize {
-            width: (data.len() as u64 + width) / width,
+            width: (data.len() + width) / width,
             height: 1,
             depth: 1,
         };

--- a/examples/compute/compute-argument-buffer.rs
+++ b/examples/compute/compute-argument-buffer.rs
@@ -6,13 +6,13 @@
 // copied, modified, or distributed except according to those terms.
 
 use metal::*;
-use objc::rc::autoreleasepool;
+use objc2::rc::autoreleasepool;
 use std::mem;
 
 static LIBRARY_SRC: &str = include_str!("compute-argument-buffer.metal");
 
 fn main() {
-    autoreleasepool(|| {
+    autoreleasepool(|_| {
         let device = Device::system_default().expect("no device found");
         let command_queue = device.new_command_queue();
 

--- a/examples/compute/embedded-lib.rs
+++ b/examples/compute/embedded-lib.rs
@@ -6,12 +6,12 @@
 // copied, modified, or distributed except according to those terms.
 
 use metal::*;
-use objc::rc::autoreleasepool;
+use objc2::rc::autoreleasepool;
 
 fn main() {
     let library_data = include_bytes!("shaders.metallib");
 
-    autoreleasepool(|| {
+    autoreleasepool(|_| {
         let device = Device::system_default().expect("no device found");
 
         let library = device.new_library_with_data(&library_data[..]).unwrap();

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -7,7 +7,7 @@ const NUM_SAMPLES: usize = 2;
 fn main() {
     let num_elements = std::env::args()
         .nth(1)
-        .map(|s| s.parse::<u32>().unwrap())
+        .map(|s| s.parse::<usize>().unwrap())
         .unwrap_or(64 * 64);
 
     autoreleasepool(|_| {
@@ -46,7 +46,7 @@ fn main() {
         let num_threads = pipeline_state.thread_execution_width();
 
         let thread_group_count = MTLSize {
-            width: ((num_elements as NSUInteger + num_threads) / num_threads),
+            width: (num_elements + num_threads) / num_threads,
             height: 1,
             depth: 1,
         };
@@ -71,9 +71,7 @@ fn main() {
         let ptr = sum.contents() as *mut u32;
         println!("Compute shader sum: {}", unsafe { *ptr });
 
-        unsafe {
-            assert_eq!(num_elements, *ptr);
-        }
+        assert_eq!(num_elements, unsafe { *ptr } as usize);
 
         handle_timestamps(&destination_buffer, cpu_start, cpu_end, gpu_start, gpu_end);
     });
@@ -162,9 +160,9 @@ fn create_counter_sample_buffer(device: &Device) -> CounterSampleBuffer {
 
 fn create_input_and_output_buffers(
     device: &Device,
-    num_elements: u32,
+    num_elements: usize,
 ) -> (metal::Buffer, metal::Buffer) {
-    let data = vec![1u32; num_elements as usize];
+    let data = vec![1u32; num_elements];
 
     let buffer = device.new_buffer_with_data(
         unsafe { std::mem::transmute(data.as_ptr()) },

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -1,5 +1,5 @@
 use metal::*;
-use objc::rc::autoreleasepool;
+use objc2::rc::autoreleasepool;
 use std::path::PathBuf;
 
 const NUM_SAMPLES: u64 = 2;
@@ -10,7 +10,7 @@ fn main() {
         .map(|s| s.parse::<u32>().unwrap())
         .unwrap_or(64 * 64);
 
-    autoreleasepool(|| {
+    autoreleasepool(|_| {
         let device = Device::system_default().expect("No device found");
         let mut cpu_start = 0;
         let mut gpu_start = 0;

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -113,12 +113,7 @@ fn resolve_samples_into_buffer(
     destination_buffer: &BufferRef,
 ) {
     let blit_encoder = command_buffer.new_blit_command_encoder();
-    blit_encoder.resolve_counters(
-        counter_sample_buffer,
-        crate::NSRange::new(0, NUM_SAMPLES),
-        destination_buffer,
-        0,
-    );
+    blit_encoder.resolve_counters(counter_sample_buffer, 0..NUM_SAMPLES, destination_buffer, 0);
     blit_encoder.end_encoding();
 }
 

--- a/examples/events/main.rs
+++ b/examples/events/main.rs
@@ -30,7 +30,7 @@ fn main() {
     let shared_event_listener = SharedEventListener::from_queue(&my_queue);
 
     // Register CPU work
-    let notify_block = block::ConcreteBlock::new(move |evt: &SharedEventRef, val: u64| {
+    let notify_block = block2::ConcreteBlock::new(move |evt: &SharedEventRef, val: u64| {
         println!("Got notification from GPU: {}", val);
         evt.set_signaled_value(3);
     });

--- a/examples/headless-render/main.rs
+++ b/examples/headless-render/main.rs
@@ -12,9 +12,9 @@ use metal::{
 };
 use png::ColorType;
 
-const VIEW_WIDTH: u64 = 512;
-const VIEW_HEIGHT: u64 = 512;
-const TOTAL_BYTES: usize = (VIEW_WIDTH * VIEW_HEIGHT * 4) as usize;
+const VIEW_WIDTH: usize = 512;
+const VIEW_HEIGHT: usize = 512;
+const TOTAL_BYTES: usize = VIEW_WIDTH * VIEW_HEIGHT * 4;
 
 const VERTEX_SHADER: &'static str = "triangle_vertex";
 const FRAGMENT_SHADER: &'static str = "triangle_fragment";
@@ -144,7 +144,7 @@ fn prepare_pipeline_state(device: &DeviceRef, library: &LibraryRef) -> RenderPip
 fn create_vertex_buffer(device: &DeviceRef) -> Buffer {
     device.new_buffer_with_data(
         VERTEX_ATTRIBS.as_ptr() as *const _,
-        (VERTEX_ATTRIBS.len() * mem::size_of::<f32>()) as u64,
+        VERTEX_ATTRIBS.len() * mem::size_of::<f32>(),
         MTLResourceOptions::CPUCacheModeDefaultCache | MTLResourceOptions::StorageModeManaged,
     )
 }

--- a/examples/mesh-shader/main.rs
+++ b/examples/mesh-shader/main.rs
@@ -1,5 +1,4 @@
 use cocoa::{appkit::NSView, base::id as cocoa_id};
-use core_graphics_types::geometry::CGSize;
 
 use metal::*;
 use objc2::{rc::autoreleasepool, runtime::Bool};

--- a/examples/mesh-shader/main.rs
+++ b/examples/mesh-shader/main.rs
@@ -43,7 +43,7 @@ fn main() {
     }
 
     let draw_size = window.inner_size();
-    layer.set_drawable_size(CGSize::new(draw_size.width as f64, draw_size.height as f64));
+    layer.set_drawable_size(draw_size.width as f64, draw_size.height as f64);
 
     let library_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("examples/mesh-shader/shaders.metallib");
@@ -75,7 +75,7 @@ fn main() {
                 Event::WindowEvent { event, .. } => match event {
                     WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                     WindowEvent::Resized(size) => {
-                        layer.set_drawable_size(CGSize::new(size.width as f64, size.height as f64));
+                        layer.set_drawable_size(size.width as f64, size.height as f64);
                     }
                     _ => (),
                 },

--- a/examples/mesh-shader/main.rs
+++ b/examples/mesh-shader/main.rs
@@ -1,10 +1,8 @@
-extern crate objc;
-
 use cocoa::{appkit::NSView, base::id as cocoa_id};
 use core_graphics_types::geometry::CGSize;
 
 use metal::*;
-use objc::{rc::autoreleasepool, runtime::YES};
+use objc2::{rc::autoreleasepool, runtime::Bool};
 use std::mem;
 use winit::platform::macos::WindowExtMacOS;
 
@@ -41,7 +39,7 @@ fn main() {
 
     unsafe {
         let view = window.ns_view() as cocoa_id;
-        view.setWantsLayer(YES);
+        view.setWantsLayer(Bool::YES.as_raw());
         view.setLayer(mem::transmute(layer.as_ref()));
     }
 
@@ -71,7 +69,7 @@ fn main() {
     let command_queue = device.new_command_queue();
 
     events_loop.run(move |event, _, control_flow| {
-        autoreleasepool(|| {
+        autoreleasepool(|_| {
             *control_flow = ControlFlow::Poll;
 
             match event {

--- a/examples/mps/main.rs
+++ b/examples/mps/main.rs
@@ -50,13 +50,13 @@ fn main() {
 
     let vertex_buffer = device.new_buffer_with_data(
         vertices.as_ptr() as *const c_void,
-        (vertex_stride * vertices.len()) as u64,
+        vertex_stride * vertices.len(),
         buffer_opts,
     );
 
     let index_buffer = device.new_buffer_with_data(
         indices.as_ptr() as *const c_void,
-        (mem::size_of::<u32>() * indices.len()) as u64,
+        mem::size_of::<u32>() * indices.len(),
         buffer_opts,
     );
 
@@ -65,7 +65,7 @@ fn main() {
         .expect("Failed to create acceleration structure");
 
     acceleration_structure.set_vertex_buffer(Some(&vertex_buffer));
-    acceleration_structure.set_vertex_stride(vertex_stride as u64);
+    acceleration_structure.set_vertex_stride(vertex_stride);
     acceleration_structure.set_index_buffer(Some(&index_buffer));
     acceleration_structure.set_index_type(mps::MPSDataType::UInt32);
     acceleration_structure.set_triangle_count(1);
@@ -75,9 +75,9 @@ fn main() {
     let ray_intersector =
         mps::RayIntersector::from_device(&device).expect("Failed to create ray intersector");
 
-    ray_intersector.set_ray_stride(mem::size_of::<Ray>() as u64);
+    ray_intersector.set_ray_stride(mem::size_of::<Ray>());
     ray_intersector.set_ray_data_type(mps::MPSRayDataType::OriginMinDistanceDirectionMaxDistance);
-    ray_intersector.set_intersection_stride(mem::size_of::<Intersection>() as u64);
+    ray_intersector.set_intersection_stride(mem::size_of::<Intersection>());
     ray_intersector.set_intersection_data_type(
         mps::MPSIntersectionDataType::DistancePrimitiveIndexCoordinates,
     );
@@ -85,12 +85,12 @@ fn main() {
     // Create a buffer to hold generated rays and intersection results
     let ray_count = 1024;
     let ray_buffer = device.new_buffer(
-        (mem::size_of::<Ray>() * ray_count) as u64,
+        mem::size_of::<Ray>() * ray_count,
         MTLResourceOptions::StorageModePrivate,
     );
 
     let intersection_buffer = device.new_buffer(
-        (mem::size_of::<Intersection>() * ray_count) as u64,
+        mem::size_of::<Intersection>() * ray_count,
         MTLResourceOptions::StorageModePrivate,
     );
 
@@ -120,7 +120,7 @@ fn main() {
         0,
         &intersection_buffer,
         0,
-        ray_count as u64,
+        ray_count,
         &acceleration_structure,
     );
 

--- a/examples/raytracing/geometry.rs
+++ b/examples/raytracing/geometry.rs
@@ -235,38 +235,23 @@ impl Geometry for TriangleGeometry {
         self.index_buffer
             .as_ref()
             .unwrap()
-            .did_modify_range(NSRange::new(
-                0,
-                self.index_buffer.as_ref().unwrap().length(),
-            ));
+            .did_modify_range(0..self.index_buffer.as_ref().unwrap().length());
         self.vertex_position_buffer
             .as_ref()
             .unwrap()
-            .did_modify_range(NSRange::new(
-                0,
-                self.vertex_position_buffer.as_ref().unwrap().length(),
-            ));
+            .did_modify_range(0..self.vertex_position_buffer.as_ref().unwrap().length());
         self.vertex_normal_buffer
             .as_ref()
             .unwrap()
-            .did_modify_range(NSRange::new(
-                0,
-                self.vertex_normal_buffer.as_ref().unwrap().length(),
-            ));
+            .did_modify_range(0..self.vertex_normal_buffer.as_ref().unwrap().length());
         self.vertex_colour_buffer
             .as_ref()
             .unwrap()
-            .did_modify_range(NSRange::new(
-                0,
-                self.vertex_colour_buffer.as_ref().unwrap().length(),
-            ));
+            .did_modify_range(0..self.vertex_colour_buffer.as_ref().unwrap().length());
         self.per_primitive_data_buffer
             .as_ref()
             .unwrap()
-            .did_modify_range(NSRange::new(
-                0,
-                self.per_primitive_data_buffer.as_ref().unwrap().length(),
-            ));
+            .did_modify_range(0..self.per_primitive_data_buffer.as_ref().unwrap().length());
 
         self.index_buffer
             .as_ref()
@@ -395,17 +380,11 @@ impl Geometry for SphereGeometry {
         self.sphere_buffer
             .as_ref()
             .unwrap()
-            .did_modify_range(NSRange::new(
-                0,
-                self.sphere_buffer.as_ref().unwrap().length(),
-            ));
+            .did_modify_range(0..self.sphere_buffer.as_ref().unwrap().length());
         self.bounding_box_buffer
             .as_ref()
             .unwrap()
-            .did_modify_range(NSRange::new(
-                0,
-                self.bounding_box_buffer.as_ref().unwrap().length(),
-            ));
+            .did_modify_range(0..self.bounding_box_buffer.as_ref().unwrap().length());
     }
 
     fn clear(&mut self) {

--- a/examples/raytracing/geometry.rs
+++ b/examples/raytracing/geometry.rs
@@ -200,35 +200,35 @@ impl Geometry for TriangleGeometry {
         self.index_buffer = Some(unsafe {
             self.device.new_buffer_with_data(
                 transmute(self.indices.as_ptr()),
-                (self.indices.len() * size_of::<u16>()) as NSUInteger,
+                self.indices.len() * size_of::<u16>(),
                 get_managed_buffer_storage_mode(),
             )
         });
         self.vertex_position_buffer = Some(unsafe {
             self.device.new_buffer_with_data(
                 transmute(self.vertices.as_ptr()),
-                (self.vertices.len() * size_of::<Vec4>()) as NSUInteger,
+                self.vertices.len() * size_of::<Vec4>(),
                 get_managed_buffer_storage_mode(),
             )
         });
         self.vertex_normal_buffer = Some(unsafe {
             self.device.new_buffer_with_data(
                 transmute(self.normals.as_ptr()),
-                (self.normals.len() * size_of::<Vec4>()) as NSUInteger,
+                self.normals.len() * size_of::<Vec4>(),
                 get_managed_buffer_storage_mode(),
             )
         });
         self.vertex_colour_buffer = Some(unsafe {
             self.device.new_buffer_with_data(
                 transmute(self.colours.as_ptr()),
-                (self.colours.len() * size_of::<Vec4>()) as NSUInteger,
+                self.colours.len() * size_of::<Vec4>(),
                 get_managed_buffer_storage_mode(),
             )
         });
         self.per_primitive_data_buffer = Some(unsafe {
             self.device.new_buffer_with_data(
                 transmute(self.triangles.as_ptr()),
-                (self.triangles.len() * size_of::<Triangle>()) as NSUInteger,
+                self.triangles.len() * size_of::<Triangle>(),
                 get_managed_buffer_storage_mode(),
             )
         });
@@ -304,12 +304,12 @@ impl Geometry for TriangleGeometry {
         descriptor.set_index_buffer(Some(self.index_buffer.as_ref().unwrap()));
         descriptor.set_index_type(MTLIndexType::UInt16);
         descriptor.set_vertex_buffer(Some(self.vertex_position_buffer.as_ref().unwrap()));
-        descriptor.set_vertex_stride(size_of::<Vec4>() as NSUInteger);
-        descriptor.set_triangle_count((self.indices.len() / 3) as NSUInteger);
+        descriptor.set_vertex_stride(size_of::<Vec4>());
+        descriptor.set_triangle_count(self.indices.len() / 3);
         descriptor
             .set_primitive_data_buffer(Some(self.per_primitive_data_buffer.as_ref().unwrap()));
-        descriptor.set_primitive_data_stride(size_of::<Triangle>() as NSUInteger);
-        descriptor.set_primitive_data_element_size(size_of::<Triangle>() as NSUInteger);
+        descriptor.set_primitive_data_stride(size_of::<Triangle>());
+        descriptor.set_primitive_data_element_size(size_of::<Triangle>());
         From::from(descriptor)
     }
 
@@ -366,7 +366,7 @@ impl Geometry for SphereGeometry {
         self.sphere_buffer = Some(unsafe {
             self.device.new_buffer_with_data(
                 transmute(self.spheres.as_ptr()),
-                (self.spheres.len() * size_of::<Sphere>()) as NSUInteger,
+                self.spheres.len() * size_of::<Sphere>(),
                 get_managed_buffer_storage_mode(),
             )
         });
@@ -384,7 +384,7 @@ impl Geometry for SphereGeometry {
         self.bounding_box_buffer = Some(unsafe {
             self.device.new_buffer_with_data(
                 transmute(bounding_boxes.as_ptr()),
-                (bounding_boxes.len() * size_of::<BoundingBox>()) as NSUInteger,
+                bounding_boxes.len() * size_of::<BoundingBox>(),
                 get_managed_buffer_storage_mode(),
             )
         });
@@ -415,10 +415,10 @@ impl Geometry for SphereGeometry {
     fn get_geometry_descriptor(&self) -> AccelerationStructureGeometryDescriptor {
         let descriptor = AccelerationStructureBoundingBoxGeometryDescriptor::descriptor();
         descriptor.set_bounding_box_buffer(Some(self.bounding_box_buffer.as_ref().unwrap()));
-        descriptor.set_bounding_box_count(self.spheres.len() as NSUInteger);
+        descriptor.set_bounding_box_count(self.spheres.len());
         descriptor.set_primitive_data_buffer(Some(&self.sphere_buffer.as_ref().unwrap()));
-        descriptor.set_primitive_data_stride(size_of::<Sphere>() as NSUInteger);
-        descriptor.set_primitive_data_element_size(size_of::<Sphere>() as NSUInteger);
+        descriptor.set_primitive_data_stride(size_of::<Sphere>());
+        descriptor.set_primitive_data_element_size(size_of::<Sphere>());
         From::from(descriptor)
     }
 
@@ -435,7 +435,7 @@ pub struct GeometryInstance {
     pub geometry: Arc<dyn Geometry>,
     pub transform: Mat4,
     pub mask: u32,
-    pub index_in_scene: NSUInteger,
+    pub index_in_scene: usize,
 }
 
 #[repr(C)]

--- a/examples/raytracing/main.rs
+++ b/examples/raytracing/main.rs
@@ -51,11 +51,10 @@ fn main() {
     }
 
     let draw_size = window.inner_size();
-    let cg_size = CGSize::new(draw_size.width as f64, draw_size.height as f64);
-    layer.set_drawable_size(cg_size);
+    layer.set_drawable_size(draw_size.width as f64, draw_size.height as f64);
 
     let mut renderer = renderer::Renderer::new(device);
-    renderer.window_resized(cg_size);
+    renderer.window_resized(draw_size.width as usize, draw_size.height as usize);
 
     events_loop.run(move |event, _, control_flow| {
         autoreleasepool(|_| {
@@ -65,9 +64,8 @@ fn main() {
                 Event::WindowEvent { event, .. } => match event {
                     WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                     WindowEvent::Resized(size) => {
-                        let size = CGSize::new(size.width as f64, size.height as f64);
-                        layer.set_drawable_size(size);
-                        renderer.window_resized(size);
+                        layer.set_drawable_size(size.width as f64, size.height as f64);
+                        renderer.window_resized(size.width as usize, size.height as usize);
                     }
                     _ => (),
                 },

--- a/examples/raytracing/main.rs
+++ b/examples/raytracing/main.rs
@@ -1,5 +1,4 @@
 use cocoa::{appkit::NSView, base::id as cocoa_id};
-use core_graphics_types::geometry::CGSize;
 use metal::*;
 use objc2::{rc::autoreleasepool, runtime::Bool};
 use std::mem;

--- a/examples/raytracing/main.rs
+++ b/examples/raytracing/main.rs
@@ -1,9 +1,7 @@
-extern crate objc;
-
 use cocoa::{appkit::NSView, base::id as cocoa_id};
 use core_graphics_types::geometry::CGSize;
 use metal::*;
-use objc::{rc::autoreleasepool, runtime::YES};
+use objc2::{rc::autoreleasepool, runtime::Bool};
 use std::mem;
 use winit::{
     event::{Event, WindowEvent},
@@ -49,7 +47,7 @@ fn main() {
 
     unsafe {
         let view = window.ns_view() as cocoa_id;
-        view.setWantsLayer(YES);
+        view.setWantsLayer(Bool::YES.as_raw());
         view.setLayer(mem::transmute(layer.as_ref()));
     }
 
@@ -61,7 +59,7 @@ fn main() {
     renderer.window_resized(cg_size);
 
     events_loop.run(move |event, _, control_flow| {
-        autoreleasepool(|| {
+        autoreleasepool(|_| {
             *control_flow = ControlFlow::Poll;
 
             match event {

--- a/examples/raytracing/renderer.rs
+++ b/examples/raytracing/renderer.rs
@@ -363,7 +363,7 @@ impl Renderer {
         self.update_uniforms();
         let command_buffer = self.queue.new_command_buffer();
         let sem = self.semaphore.clone();
-        let block = block::ConcreteBlock::new(move |_| {
+        let block = block2::ConcreteBlock::new(move |_| {
             sem.release();
         })
         .copy();

--- a/examples/raytracing/renderer.rs
+++ b/examples/raytracing/renderer.rs
@@ -265,7 +265,7 @@ impl Renderer {
             frame_index: 0,
             uniform_buffer_index: 0,
             uniform_buffer_offset: 0,
-            size: CGSize::new(1024 as CGFloat, 1024 as CGFloat),
+            size: CGSize::new(1024.0, 1024.0),
             semaphore: Semaphore::new((MAX_FRAMES_IN_FLIGHT - 2) as usize),
             instance_buffer,
             queue,

--- a/examples/raytracing/renderer.rs
+++ b/examples/raytracing/renderer.rs
@@ -291,7 +291,7 @@ impl Renderer {
     pub fn window_resized(&mut self, size: CGSize) {
         self.size = size;
         let texture_descriptor =
-            Self::create_target_descriptor(size.width() as NSUInteger, size.height() as NSUInteger);
+            Self::create_target_descriptor(size.width as NSUInteger, size.height as NSUInteger);
         self.accumulation_targets[0] = self.device.new_texture(&texture_descriptor);
         self.accumulation_targets[1] = self.device.new_texture(&texture_descriptor);
         texture_descriptor.set_pixel_format(MTLPixelFormat::R32Uint);
@@ -299,20 +299,15 @@ impl Renderer {
         texture_descriptor.set_storage_mode(MTLStorageMode::Managed);
         self.random_texture = self.device.new_texture(&texture_descriptor);
         let mut rng = thread_rng();
-        let mut random_values = vec![0u32; (size.width() * size.height()) as usize];
+        let mut random_values = vec![0u32; (size.width * size.height) as usize];
         for v in &mut random_values {
             *v = rng.next_u32();
         }
         self.random_texture.replace_region(
-            MTLRegion::new_2d(
-                0,
-                0,
-                size.width() as NSUInteger,
-                size.height() as NSUInteger,
-            ),
+            MTLRegion::new_2d(0, 0, size.width as NSUInteger, size.height as NSUInteger),
             0,
             random_values.as_ptr() as *const c_void,
-            size_of::<u32>() as NSUInteger * size.width() as NSUInteger,
+            size_of::<u32>() as NSUInteger * size.width as NSUInteger,
         );
         self.frame_index = 0;
     }
@@ -339,15 +334,15 @@ impl Renderer {
         uniforms.camera.up = Vec4::from((up, 0.0));
 
         let field_of_view = 45.0 * (std::f32::consts::PI / 180.0);
-        let aspect_ratio = self.size.width() as f32 / self.size.height() as f32;
+        let aspect_ratio = self.size.width as f32 / self.size.height as f32;
         let image_plane_height = f32::tan(field_of_view / 2.0);
         let image_plane_width = aspect_ratio * image_plane_height;
 
         uniforms.camera.right *= image_plane_width;
         uniforms.camera.up *= image_plane_height;
 
-        uniforms.width = self.size.width() as u32;
-        uniforms.height = self.size.height() as u32;
+        uniforms.width = self.size.width as u32;
+        uniforms.height = self.size.height as u32;
 
         uniforms.frame_index = self.frame_index as u32;
         self.frame_index += 1;
@@ -372,8 +367,8 @@ impl Renderer {
         })
         .copy();
         command_buffer.add_completed_handler(&block);
-        let width = self.size.width() as NSUInteger;
-        let height = self.size.height() as NSUInteger;
+        let width = self.size.width as NSUInteger;
+        let height = self.size.height as NSUInteger;
         let threads_per_thread_group = MTLSize::new(8, 8, 1);
         let thread_groups = MTLSize::new(
             (width + threads_per_thread_group.width - 1) / threads_per_thread_group.width,

--- a/examples/raytracing/renderer.rs
+++ b/examples/raytracing/renderer.rs
@@ -127,7 +127,7 @@ impl Renderer {
             get_managed_buffer_storage_mode(),
         );
         resource_buffer.set_label("resource buffer");
-        resource_buffer.did_modify_range(NSRange::new(0, resource_buffer.length()));
+        resource_buffer.did_modify_range(0..resource_buffer.length());
 
         let mut primitive_acceleration_structures = Vec::new();
         for i in 0..scene.geometries.len() {
@@ -178,7 +178,7 @@ impl Renderer {
             get_managed_buffer_storage_mode(),
         );
         instance_buffer.set_label("instance buffer");
-        instance_buffer.did_modify_range(NSRange::new(0, instance_buffer.length()));
+        instance_buffer.did_modify_range(0..instance_buffer.length());
 
         let accel_descriptor = InstanceAccelerationStructureDescriptor::descriptor();
         accel_descriptor.set_instanced_acceleration_structures(&Array::from_owned_slice(
@@ -348,10 +348,9 @@ impl Renderer {
 
         uniforms.light_count = self.scene.lights.len() as u32;
 
-        self.uniform_buffer.did_modify_range(NSRange {
-            location: self.uniform_buffer_offset,
-            length: ALIGNED_UNIFORMS_SIZE,
-        });
+        self.uniform_buffer.did_modify_range(
+            self.uniform_buffer_offset..(self.uniform_buffer_offset + ALIGNED_UNIFORMS_SIZE),
+        );
 
         self.uniform_buffer_index = (self.uniform_buffer_index + 1) % MAX_FRAMES_IN_FLIGHT;
     }

--- a/examples/raytracing/renderer.rs
+++ b/examples/raytracing/renderer.rs
@@ -1,4 +1,3 @@
-use core_graphics_types::{base::CGFloat, geometry::CGSize};
 use std::{
     collections::BTreeMap,
     ffi::c_void,
@@ -292,7 +291,7 @@ impl Renderer {
     pub fn window_resized(&mut self, size: CGSize) {
         self.size = size;
         let texture_descriptor =
-            Self::create_target_descriptor(size.width as NSUInteger, size.height as NSUInteger);
+            Self::create_target_descriptor(size.width() as NSUInteger, size.height() as NSUInteger);
         self.accumulation_targets[0] = self.device.new_texture(&texture_descriptor);
         self.accumulation_targets[1] = self.device.new_texture(&texture_descriptor);
         texture_descriptor.set_pixel_format(MTLPixelFormat::R32Uint);
@@ -300,15 +299,20 @@ impl Renderer {
         texture_descriptor.set_storage_mode(MTLStorageMode::Managed);
         self.random_texture = self.device.new_texture(&texture_descriptor);
         let mut rng = thread_rng();
-        let mut random_values = vec![0u32; (size.width * size.height) as usize];
+        let mut random_values = vec![0u32; (size.width() * size.height()) as usize];
         for v in &mut random_values {
             *v = rng.next_u32();
         }
         self.random_texture.replace_region(
-            MTLRegion::new_2d(0, 0, size.width as NSUInteger, size.height as NSUInteger),
+            MTLRegion::new_2d(
+                0,
+                0,
+                size.width() as NSUInteger,
+                size.height() as NSUInteger,
+            ),
             0,
             random_values.as_ptr() as *const c_void,
-            size_of::<u32>() as NSUInteger * size.width as NSUInteger,
+            size_of::<u32>() as NSUInteger * size.width() as NSUInteger,
         );
         self.frame_index = 0;
     }
@@ -335,15 +339,15 @@ impl Renderer {
         uniforms.camera.up = Vec4::from((up, 0.0));
 
         let field_of_view = 45.0 * (std::f32::consts::PI / 180.0);
-        let aspect_ratio = self.size.width as f32 / self.size.height as f32;
+        let aspect_ratio = self.size.width() as f32 / self.size.height() as f32;
         let image_plane_height = f32::tan(field_of_view / 2.0);
         let image_plane_width = aspect_ratio * image_plane_height;
 
         uniforms.camera.right *= image_plane_width;
         uniforms.camera.up *= image_plane_height;
 
-        uniforms.width = self.size.width as u32;
-        uniforms.height = self.size.height as u32;
+        uniforms.width = self.size.width() as u32;
+        uniforms.height = self.size.height() as u32;
 
         uniforms.frame_index = self.frame_index as u32;
         self.frame_index += 1;
@@ -368,8 +372,8 @@ impl Renderer {
         })
         .copy();
         command_buffer.add_completed_handler(&block);
-        let width = self.size.width as NSUInteger;
-        let height = self.size.height as NSUInteger;
+        let width = self.size.width() as NSUInteger;
+        let height = self.size.height() as NSUInteger;
         let threads_per_thread_group = MTLSize::new(8, 8, 1);
         let thread_groups = MTLSize::new(
             (width + threads_per_thread_group.width - 1) / threads_per_thread_group.width,

--- a/examples/raytracing/scene.rs
+++ b/examples/raytracing/scene.rs
@@ -3,7 +3,7 @@ use std::{ffi::c_void, mem::size_of, sync::Arc};
 use glam::{Mat4, Vec3, Vec4};
 use rand::{thread_rng, Rng};
 
-use metal::{Buffer, Device, NSRange};
+use metal::{Buffer, Device};
 
 use super::{camera::Camera, geometry::*};
 
@@ -120,7 +120,7 @@ impl Scene {
             lights.len() * size_of::<AreaLight>(),
             get_managed_buffer_storage_mode(),
         );
-        lights_buffer.did_modify_range(NSRange::new(0, lights_buffer.length()));
+        lights_buffer.did_modify_range(0..lights_buffer.length());
         lights_buffer.set_label("lights buffer");
 
         Self {

--- a/examples/raytracing/scene.rs
+++ b/examples/raytracing/scene.rs
@@ -3,7 +3,7 @@ use std::{ffi::c_void, mem::size_of, sync::Arc};
 use glam::{Mat4, Vec3, Vec4};
 use rand::{thread_rng, Rng};
 
-use metal::{Buffer, Device, NSRange, NSUInteger};
+use metal::{Buffer, Device, NSRange};
 
 use super::{camera::Camera, geometry::*};
 
@@ -117,7 +117,7 @@ impl Scene {
         }
         let lights_buffer = device.new_buffer_with_data(
             lights.as_ptr() as *const c_void,
-            (lights.len() * size_of::<AreaLight>()) as NSUInteger,
+            lights.len() * size_of::<AreaLight>(),
             get_managed_buffer_storage_mode(),
         );
         lights_buffer.did_modify_range(NSRange::new(0, lights_buffer.length()));

--- a/examples/reflection/main.rs
+++ b/examples/reflection/main.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use metal::*;
-use objc::rc::autoreleasepool;
+use objc2::rc::autoreleasepool;
 
 const PROGRAM: &'static str = r"
     #include <metal_stdlib>
@@ -41,7 +41,7 @@ const PROGRAM: &'static str = r"
 ";
 
 fn main() {
-    autoreleasepool(|| {
+    autoreleasepool(|_| {
         let device = Device::system_default().expect("no device found");
 
         let options = CompileOptions::new();

--- a/examples/shader-dylib/main.rs
+++ b/examples/shader-dylib/main.rs
@@ -48,7 +48,7 @@ impl App {
             view.setLayer(mem::transmute(layer.as_ref()));
         }
         let draw_size = window.inner_size();
-        layer.set_drawable_size(CGSize::new(draw_size.width as f64, draw_size.height as f64));
+        layer.set_drawable_size(draw_size.width as f64, draw_size.height as f64);
 
         // compile dynamic lib shader
         let dylib_src_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -108,8 +108,7 @@ impl App {
     }
 
     fn resize(&mut self, width: u32, height: u32) {
-        self.layer
-            .set_drawable_size(CGSize::new(width as f64, height as f64));
+        self.layer.set_drawable_size(width as f64, height as f64);
         self.width = width;
         self.height = height;
     }

--- a/examples/shader-dylib/main.rs
+++ b/examples/shader-dylib/main.rs
@@ -1,5 +1,4 @@
 use cocoa::{appkit::NSView, base::id as cocoa_id};
-use core_graphics_types::geometry::CGSize;
 
 use metal::*;
 use objc2::rc::autoreleasepool;

--- a/examples/shader-dylib/main.rs
+++ b/examples/shader-dylib/main.rs
@@ -2,7 +2,8 @@ use cocoa::{appkit::NSView, base::id as cocoa_id};
 use core_graphics_types::geometry::CGSize;
 
 use metal::*;
-use objc::{rc::autoreleasepool, runtime::YES};
+use objc2::rc::autoreleasepool;
+use objc2::runtime::Bool;
 
 use winit::{
     event::{Event, WindowEvent},
@@ -44,7 +45,7 @@ impl App {
         layer.set_framebuffer_only(false);
         unsafe {
             let view = window.ns_view() as cocoa_id;
-            view.setWantsLayer(YES);
+            view.setWantsLayer(Bool::YES.as_raw());
             view.setLayer(mem::transmute(layer.as_ref()));
         }
         let draw_size = window.inner_size();
@@ -153,7 +154,7 @@ fn main() {
     let mut app = App::new(&window);
 
     events_loop.run(move |event, _, control_flow| {
-        autoreleasepool(|| {
+        autoreleasepool(|_| {
             *control_flow = ControlFlow::Poll;
 
             match event {

--- a/examples/texture/Cargo.toml
+++ b/examples/texture/Cargo.toml
@@ -13,4 +13,8 @@ cocoa = "0.24"
 png = "0.17"
 metal = { path = "../../" }
 winit = "0.27"
-objc2 = "=0.3.0-beta.2"
+objc2 = "=0.3.0-beta.4"
+
+[dependencies.icrate]
+version = "0.0.1"
+features = ["Foundation"]

--- a/examples/texture/Cargo.toml
+++ b/examples/texture/Cargo.toml
@@ -13,8 +13,8 @@ cocoa = "0.24"
 png = "0.17"
 metal = { path = "../../" }
 winit = "0.27"
-objc2 = "=0.3.0-beta.4"
+objc2 = "=0.3.0-beta.5"
 
 [dependencies.icrate]
-version = "0.0.1"
+version = "0.0.2"
 features = ["Foundation"]

--- a/examples/texture/Cargo.toml
+++ b/examples/texture/Cargo.toml
@@ -9,8 +9,6 @@ edition = "2018"
 bindgen = { version = "0.60", default-features = false, features = ["logging", "runtime", "which-rustfmt"] }
 
 [dependencies]
-# Branch: objc2. TODO: Remove this
-core-graphics-types = { git = "https://github.com/madsmtm/core-foundation-rs.git", rev = "7d593d016175755e492a92ef89edca68ac3bd5cd" }
 cocoa = "0.24"
 png = "0.17"
 metal = { path = "../../" }

--- a/examples/texture/Cargo.toml
+++ b/examples/texture/Cargo.toml
@@ -9,13 +9,10 @@ edition = "2018"
 bindgen = { version = "0.60", default-features = false, features = ["logging", "runtime", "which-rustfmt"] }
 
 [dependencies]
-core-graphics-types = "0.1"
+# Branch: objc2. TODO: Remove this
+core-graphics-types = { git = "https://github.com/madsmtm/core-foundation-rs.git", rev = "7d593d016175755e492a92ef89edca68ac3bd5cd" }
 cocoa = "0.24"
-core-graphics = "0.22"
 png = "0.17"
 metal = { path = "../../" }
 winit = "0.27"
-
-[dependencies.objc]
-version = "0.2.4"
-features = ["objc_exception"]
+objc2 = "=0.3.0-beta.2"

--- a/examples/texture/Cargo.toml
+++ b/examples/texture/Cargo.toml
@@ -13,8 +13,8 @@ cocoa = "0.24"
 png = "0.17"
 metal = { path = "../../" }
 winit = "0.27"
-objc2 = "=0.3.0-beta.5"
+objc2 = "0.4.1"
 
 [dependencies.icrate]
-version = "0.0.2"
+version = "0.0.4"
 features = ["Foundation"]

--- a/examples/texture/src/main.rs
+++ b/examples/texture/src/main.rs
@@ -230,7 +230,7 @@ fn update_viewport_size_buffer(viewport_size_buffer: &Buffer, size: (u32, u32)) 
     unsafe {
         std::ptr::copy(viewport_size.as_ptr(), contents as *mut u32, byte_count);
     }
-    viewport_size_buffer.did_modify_range(NSRange::new(0, byte_count));
+    viewport_size_buffer.did_modify_range(0..byte_count);
 }
 
 fn redraw(

--- a/examples/texture/src/main.rs
+++ b/examples/texture/src/main.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use cocoa::{appkit::NSView, base::id as cocoa_id};
 use core_graphics_types::geometry::CGSize;
-use objc::rc::autoreleasepool;
+use objc2::rc::autoreleasepool;
 use winit::dpi::LogicalSize;
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::platform::macos::WindowExtMacOS;
@@ -58,7 +58,7 @@ fn main() {
     let command_queue = device.new_command_queue();
 
     event_loop.run(move |event, _, control_flow| {
-        autoreleasepool(|| {
+        autoreleasepool(|_| {
             *control_flow = ControlFlow::Poll;
 
             match event {

--- a/examples/texture/src/main.rs
+++ b/examples/texture/src/main.rs
@@ -167,10 +167,10 @@ fn get_window_layer(window: &Window, device: &Device) -> MetalLayer {
     // https://developer.apple.com/documentation/quartzcore/cametallayer/1478157-presentswithtransaction
     layer.set_presents_with_transaction(false);
 
-    layer.set_drawable_size(CGSize::new(
+    layer.set_drawable_size(
         window.inner_size().width as f64,
         window.inner_size().height as f64,
-    ));
+    );
 
     unsafe {
         let view = window.ns_view() as cocoa_id;
@@ -214,7 +214,7 @@ fn handle_window_event(
     match event {
         WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
         WindowEvent::Resized(size) => {
-            layer.set_drawable_size(CGSize::new(size.width as f64, size.height as f64));
+            layer.set_drawable_size(size.width as f64, size.height as f64);
 
             update_viewport_size_buffer(viewport_size_buffer, (size.width, size.height));
         }

--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -5,13 +5,12 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate objc;
-
 use cocoa::{appkit::NSView, base::id as cocoa_id};
 use core_graphics_types::geometry::CGSize;
 
 use metal::*;
-use objc::{rc::autoreleasepool, runtime::YES};
+use objc2::rc::autoreleasepool;
+use objc2::runtime::Bool;
 use std::mem;
 use winit::platform::macos::WindowExtMacOS;
 
@@ -103,7 +102,7 @@ fn main() {
 
     unsafe {
         let view = window.ns_view() as cocoa_id;
-        view.setWantsLayer(YES);
+        view.setWantsLayer(Bool::YES.as_raw());
         view.setLayer(mem::transmute(layer.as_ref()));
     }
 
@@ -162,7 +161,7 @@ fn main() {
     );
 
     events_loop.run(move |event, _, control_flow| {
-        autoreleasepool(|| {
+        autoreleasepool(|_| {
             *control_flow = ControlFlow::Poll;
 
             match event {

--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -106,7 +106,7 @@ fn main() {
     }
 
     let draw_size = window.inner_size();
-    layer.set_drawable_size(CGSize::new(draw_size.width as f64, draw_size.height as f64));
+    layer.set_drawable_size(draw_size.width as f64, draw_size.height as f64);
 
     let library_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("examples/window/shaders.metallib");
@@ -167,7 +167,7 @@ fn main() {
                 Event::WindowEvent { event, .. } => match event {
                     WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                     WindowEvent::Resized(size) => {
-                        layer.set_drawable_size(CGSize::new(size.width as f64, size.height as f64));
+                        layer.set_drawable_size(size.width as f64, size.height as f64);
                     }
                     _ => (),
                 },

--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -202,10 +202,7 @@ fn main() {
                         );
                     }
 
-                    vbuf.did_modify_range(NSRange::new(
-                        0,
-                        vertex_data.len() * mem::size_of::<f32>(),
-                    ));
+                    vbuf.did_modify_range(0..vertex_data.len() * mem::size_of::<f32>());
 
                     let drawable = match layer.next_drawable() {
                         Some(drawable) => drawable,

--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use cocoa::{appkit::NSView, base::id as cocoa_id};
-use core_graphics_types::geometry::CGSize;
 
 use metal::*;
 use objc2::rc::autoreleasepool;
@@ -132,7 +131,7 @@ fn main() {
 
         device.new_buffer_with_data(
             vertex_data.as_ptr() as *const _,
-            (vertex_data.len() * mem::size_of::<f32>()) as u64,
+            vertex_data.len() * mem::size_of::<f32>(),
             MTLResourceOptions::CPUCacheModeDefaultCache | MTLResourceOptions::StorageModeManaged,
         )
     };
@@ -156,7 +155,7 @@ fn main() {
 
     let clear_rect_buffer = device.new_buffer_with_data(
         clear_rect.as_ptr() as *const _,
-        mem::size_of::<ClearRect>() as u64,
+        mem::size_of::<ClearRect>(),
         MTLResourceOptions::CPUCacheModeDefaultCache | MTLResourceOptions::StorageModeManaged,
     );
 
@@ -199,13 +198,13 @@ fn main() {
                         std::ptr::copy(
                             vertex_data.as_ptr(),
                             p as *mut f32,
-                            (vertex_data.len() * mem::size_of::<f32>()) as usize,
+                            vertex_data.len() * mem::size_of::<f32>(),
                         );
                     }
 
-                    vbuf.did_modify_range(crate::NSRange::new(
-                        0 as u64,
-                        (vertex_data.len() * mem::size_of::<f32>()) as u64,
+                    vbuf.did_modify_range(NSRange::new(
+                        0,
+                        vertex_data.len() * mem::size_of::<f32>(),
                     ));
 
                     let drawable = match layer.next_drawable() {

--- a/guide/internals/README.md
+++ b/guide/internals/README.md
@@ -1,6 +1,6 @@
 Under the hood, `metal-rs` is powered by three main dependencies.
 
-[rust-objc] and [rust-block] and [foreign-types].
+[`objc2`] and [`block2`] and [`foreign-types`].
 
 These dependencies are used to communicate with the [Objective-C runtime] in order to allocate, de-allocate and call methods on the classes and objects that power Metal applications.
 
@@ -50,8 +50,8 @@ foreign_obj_type! {
 
 ensures that when the owned `StencilDescriptor` is dropped it will call `release` on the backing Objective-C object, leading to the memory being deallocated.
 
-[rust-objc]: https://github.com/SSheldon/rust-objc
-[rust-block]: https://github.com/SSheldon/rust-block
-[foreign-types]: https://github.com/sfackler/foreign-types
+[`objc2`]: https://crates.io/crates/objc2
+[`block2`]: https://crates.io/crates/block2
+[`foreign-types`]: https://crates.io/crates/foreign-types
 [Objective-C runtime]: https://developer.apple.com/documentation/objectivec/objective-c_runtime
 [memory management policy]: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmRules.html#//apple_ref/doc/uid/20000994-BAJHFBGH

--- a/src/accelerator_structure.rs
+++ b/src/accelerator_structure.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::os::raw::c_float;
+
 use super::*;
 
 bitflags! {
@@ -18,6 +20,10 @@ bitflags! {
     }
 }
 
+unsafe impl Encode for MTLAccelerationStructureInstanceOptions {
+    const ENCODING: Encoding = u32::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlaccelerationstructureinstancedescriptortype>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -26,6 +32,10 @@ pub enum MTLAccelerationStructureInstanceDescriptorType {
     Default = 0,
     UserID = 1,
     Motion = 2,
+}
+
+unsafe impl Encode for MTLAccelerationStructureInstanceDescriptorType {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
@@ -38,6 +48,39 @@ pub struct MTLAccelerationStructureInstanceDescriptor {
     pub acceleration_structure_index: u32,
 }
 
+const PACKED_FLOAT_4_3_ENCODING: Encoding = Encoding::Struct(
+    "_MTLPackedFloat4x3",
+    &[Encoding::Array(
+        4,
+        &Encoding::Struct(
+            "_MTLPackedFloat3",
+            &[Encoding::Union(
+                "?",
+                &[
+                    Encoding::Struct(
+                        "?",
+                        &[c_float::ENCODING, c_float::ENCODING, c_float::ENCODING],
+                    ),
+                    Encoding::Array(3, &c_float::ENCODING),
+                ],
+            )],
+        ),
+    )],
+);
+
+unsafe impl Encode for MTLAccelerationStructureInstanceDescriptor {
+    const ENCODING: Encoding = Encoding::Struct(
+        "?",
+        &[
+            PACKED_FLOAT_4_3_ENCODING,
+            MTLAccelerationStructureInstanceOptions::ENCODING,
+            u32::ENCODING,
+            u32::ENCODING,
+            u32::ENCODING,
+        ],
+    );
+}
+
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 #[repr(C)]
 pub struct MTLAccelerationStructureUserIDInstanceDescriptor {
@@ -47,6 +90,20 @@ pub struct MTLAccelerationStructureUserIDInstanceDescriptor {
     pub intersection_function_table_offset: u32,
     pub acceleration_structure_index: u32,
     pub user_id: u32,
+}
+
+unsafe impl Encode for MTLAccelerationStructureUserIDInstanceDescriptor {
+    const ENCODING: Encoding = Encoding::Struct(
+        "?",
+        &[
+            PACKED_FLOAT_4_3_ENCODING,
+            MTLAccelerationStructureInstanceOptions::ENCODING,
+            u32::ENCODING,
+            u32::ENCODING,
+            u32::ENCODING,
+            u32::ENCODING,
+        ],
+    );
 }
 
 pub enum MTLAccelerationStructureDescriptor {}

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -158,11 +158,11 @@ impl StructMemberRef {
         unsafe { msg_send![self, dataType] }
     }
 
-    pub fn struct_type(&self) -> MTLStructType {
+    pub fn struct_type(&self) -> &StructTypeRef {
         unsafe { msg_send![self, structType] }
     }
 
-    pub fn array_type(&self) -> MTLArrayType {
+    pub fn array_type(&self) -> &ArrayTypeRef {
         unsafe { msg_send![self, arrayType] }
     }
 }
@@ -225,11 +225,11 @@ impl ArrayTypeRef {
         unsafe { msg_send![self, elementType] }
     }
 
-    pub fn element_struct_type(&self) -> MTLStructType {
+    pub fn element_struct_type(&self) -> &StructTypeRef {
         unsafe { msg_send![self, elementStructType] }
     }
 
-    pub fn element_array_type(&self) -> MTLArrayType {
+    pub fn element_array_type(&self) -> &ArrayTypeRef {
         unsafe { msg_send![self, elementArrayType] }
     }
 }

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -5,8 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use super::{MTLTextureType, NSUInteger};
-use objc::runtime::{NO, YES};
+use super::*;
 
 /// See <https://developer.apple.com/documentation/metal/mtldatatype>
 #[repr(u64)]
@@ -108,6 +107,10 @@ pub enum MTLDataType {
     RGB9E5Float = 77,
 }
 
+unsafe impl Encode for MTLDataType {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlargumenttype>
 #[repr(u64)]
 #[deprecated(
@@ -124,6 +127,10 @@ pub enum MTLArgumentType {
     Imageblock = 17,
 }
 
+unsafe impl Encode for MTLArgumentType {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlargumentaccess>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -132,6 +139,10 @@ pub enum MTLArgumentAccess {
     ReadOnly = 0,
     ReadWrite = 1,
     WriteOnly = 2,
+}
+
+unsafe impl Encode for MTLArgumentAccess {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlstructmember>

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -25,7 +25,8 @@ impl BufferRef {
         unsafe { msg_send![self, contents] }
     }
 
-    pub fn did_modify_range(&self, range: NSRange) {
+    pub fn did_modify_range(&self, range: Range<usize>) {
+        let range: NSRange = range.into();
         unsafe { msg_send![self, didModifyRange: range] }
     }
 
@@ -54,7 +55,8 @@ impl BufferRef {
         unsafe { msg_send![self, newRemoteBufferViewForDevice: device] }
     }
 
-    pub fn add_debug_marker(&self, name: &str, range: NSRange) {
+    pub fn add_debug_marker(&self, name: &str, range: Range<usize>) {
+        let range: NSRange = range.into();
         unsafe {
             let name = crate::nsstring_from_str(name);
             msg_send![self, addDebugMarker:name range:range]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -17,7 +17,7 @@ foreign_obj_type! {
 }
 
 impl BufferRef {
-    pub fn length(&self) -> u64 {
+    pub fn length(&self) -> usize {
         unsafe { msg_send![self, length] }
     }
 
@@ -25,15 +25,15 @@ impl BufferRef {
         unsafe { msg_send![self, contents] }
     }
 
-    pub fn did_modify_range(&self, range: crate::NSRange) {
+    pub fn did_modify_range(&self, range: NSRange) {
         unsafe { msg_send![self, didModifyRange: range] }
     }
 
     pub fn new_texture_with_descriptor(
         &self,
         descriptor: &TextureDescriptorRef,
-        offset: u64,
-        bytes_per_row: u64,
+        offset: usize,
+        bytes_per_row: usize,
     ) -> Texture {
         unsafe {
             msg_send![self,
@@ -54,7 +54,7 @@ impl BufferRef {
         unsafe { msg_send![self, newRemoteBufferViewForDevice: device] }
     }
 
-    pub fn add_debug_marker(&self, name: &str, range: crate::NSRange) {
+    pub fn add_debug_marker(&self, name: &str, range: NSRange) {
         unsafe {
             let name = crate::nsstring_from_str(name);
             msg_send![self, addDebugMarker:name range:range]

--- a/src/capturedescriptor.rs
+++ b/src/capturedescriptor.rs
@@ -18,6 +18,10 @@ pub enum MTLCaptureDestination {
     GpuTraceDocument = 2,
 }
 
+unsafe impl Encode for MTLCaptureDestination {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlcapturedescriptor>
 pub enum MTLCaptureDescriptor {}
 

--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-use block::Block;
+use block2::Block;
 
 /// See <https://developer.apple.com/documentation/metal/mtlcommandbufferstatus>
 #[repr(u32)]
@@ -20,6 +20,10 @@ pub enum MTLCommandBufferStatus {
     Scheduled = 3,
     Completed = 4,
     Error = 5,
+}
+
+unsafe impl Encode for MTLCommandBufferStatus {
+    const ENCODING: Encoding = u32::ENCODING;
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlcommandbuffererror>
@@ -39,6 +43,10 @@ pub enum MTLCommandBufferError {
     DeviceRemoved = 11,
 }
 
+unsafe impl Encode for MTLCommandBufferError {
+    const ENCODING: Encoding = u32::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtldispatchtype>
 #[repr(u32)]
 #[allow(non_camel_case_types)]
@@ -46,6 +54,10 @@ pub enum MTLCommandBufferError {
 pub enum MTLDispatchType {
     Serial = 0,
     Concurrent = 1,
+}
+
+unsafe impl Encode for MTLDispatchType {
+    const ENCODING: Encoding = u32::ENCODING;
 }
 
 type CommandBufferHandler<'a> = Block<(&'a CommandBufferRef,), ()>;
@@ -56,6 +68,10 @@ pub enum MTLCommandBuffer {}
 foreign_obj_type! {
     type CType = MTLCommandBuffer;
     pub struct CommandBuffer;
+}
+
+unsafe impl Encode for CommandBufferRef {
+    const ENCODING: Encoding = Encoding::Unknown; // TODO
 }
 
 impl CommandBufferRef {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use super::*;
+
 /// See <https://developer.apple.com/documentation/metal/mtlpixelformat>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -149,4 +151,8 @@ pub enum MTLPixelFormat {
     BGRA10_XR_SRGB = 553,
     BGR10_XR = 554,
     BGR10_XR_SRGB = 555,
+}
+
+unsafe impl Encode for MTLPixelFormat {
+    const ENCODING: Encoding = u64::ENCODING;
 }

--- a/src/depthstencil.rs
+++ b/src/depthstencil.rs
@@ -5,8 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::DeviceRef;
-use objc::runtime::{NO, YES};
+use super::*;
 
 /// See <https://developer.apple.com/documentation/metal/mtlcomparefunction>
 #[repr(u64)]
@@ -22,6 +21,10 @@ pub enum MTLCompareFunction {
     Always = 7,
 }
 
+unsafe impl Encode for MTLCompareFunction {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlstenciloperation>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -34,6 +37,10 @@ pub enum MTLStencilOperation {
     Invert = 5,
     IncrementWrap = 6,
     DecrementWrap = 7,
+}
+
+unsafe impl Encode for MTLStencilOperation {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlstencildescriptor>

--- a/src/device.rs
+++ b/src/device.rs
@@ -1796,7 +1796,7 @@ impl DeviceRef {
 
             let state = RenderPipelineState::from_ptr(pipeline_state);
 
-            let () = msg_send![reflection, retain];
+            let reflection: *mut AnyObject = msg_send![reflection, retain];
             let reflection = RenderPipelineReflection::from_ptr(reflection as _);
 
             Ok((state, reflection))
@@ -1834,7 +1834,7 @@ impl DeviceRef {
 
             let state = RenderPipelineState::from_ptr(pipeline_state);
 
-            let () = msg_send![reflection, retain];
+            let reflection: *mut AnyObject = msg_send![reflection, retain];
             let reflection = RenderPipelineReflection::from_ptr(reflection as _);
 
             Ok((state, reflection))
@@ -1902,7 +1902,7 @@ impl DeviceRef {
 
             let state = ComputePipelineState::from_ptr(pipeline_state);
 
-            let () = msg_send![reflection, retain];
+            let reflection: *mut AnyObject = msg_send![reflection, retain];
             let reflection = ComputePipelineReflection::from_ptr(reflection as _);
 
             Ok((state, reflection))
@@ -2109,7 +2109,7 @@ impl DeviceRef {
             let ret = (0..count)
                 .map(|i| {
                     let csp: *mut MTLCounterSet = msg_send![counter_sets, objectAtIndex: i];
-                    let () = msg_send![csp, retain];
+                    let csp: *mut MTLCounterSet = msg_send![csp, retain];
                     CounterSet::from_ptr(csp)
                 })
                 .collect();

--- a/src/device.rs
+++ b/src/device.rs
@@ -1501,6 +1501,9 @@ unsafe impl Encode for MTLAccelerationStructureSizes {
     );
 }
 
+// Note: For some reason it is required by `MTLCreateSystemDefaultDevice`
+// that we link to `CoreGraphics`?
+#[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
 #[cfg_attr(feature = "link", link(name = "Metal", kind = "framework"))]
 extern "C" {
     fn MTLCreateSystemDefaultDevice() -> *mut MTLDevice;
@@ -1952,7 +1955,7 @@ impl DeviceRef {
         }
     }
 
-    pub fn new_buffer(&self, length: u64, options: MTLResourceOptions) -> Buffer {
+    pub fn new_buffer(&self, length: NSUInteger, options: MTLResourceOptions) -> Buffer {
         unsafe {
             msg_send![self, newBufferWithLength:length
                                         options:options]

--- a/src/device.rs
+++ b/src/device.rs
@@ -7,9 +7,9 @@
 
 use super::*;
 
-use block::{Block, ConcreteBlock};
+use block2::{Block, ConcreteBlock};
 use foreign_types::ForeignType;
-use objc::runtime::{Object, NO, YES};
+use objc2::runtime::Object;
 
 use std::{ffi::CStr, os::raw::c_char, path::Path, ptr};
 
@@ -57,6 +57,10 @@ pub enum MTLFeatureSet {
     macOS_GPUFamily2_v1 = 10005,
 }
 
+unsafe impl Encode for MTLFeatureSet {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// Available on macOS 10.15+, iOS 13.0+
 ///
 /// See <https://developer.apple.com/documentation/metal/mtlgpufamily>
@@ -83,6 +87,10 @@ pub enum MTLGPUFamily {
     Metal3 = 5001,
 }
 
+unsafe impl Encode for MTLGPUFamily {
+    const ENCODING: Encoding = i64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtldevicelocation>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -91,6 +99,10 @@ pub enum MTLDeviceLocation {
     Slot = 1,
     External = 2,
     Unspecified = u64::MAX,
+}
+
+unsafe impl Encode for MTLDeviceLocation {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 bitflags! {
@@ -1398,6 +1410,10 @@ pub enum MTLArgumentBuffersTier {
     Tier2 = 1,
 }
 
+unsafe impl Encode for MTLArgumentBuffersTier {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlreadwritetexturetier>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -1405,6 +1421,10 @@ pub enum MTLReadWriteTextureTier {
     TierNone = 0,
     Tier1 = 1,
     Tier2 = 2,
+}
+
+unsafe impl Encode for MTLReadWriteTextureTier {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 /// Only available on (macos(11.0), ios(14.0))
@@ -1420,6 +1440,10 @@ pub enum MTLCounterSamplingPoint {
     AtBlitBoundary = 4,
 }
 
+unsafe impl Encode for MTLCounterSamplingPoint {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// Only available on (macos(11.0), macCatalyst(14.0), ios(13.0))
 /// Kinda a long name!
 ///
@@ -1429,6 +1453,10 @@ pub enum MTLCounterSamplingPoint {
 pub enum MTLSparseTextureRegionAlignmentMode {
     Outward = 0,
     Inward = 1,
+}
+
+unsafe impl Encode for MTLSparseTextureRegionAlignmentMode {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 bitflags! {
@@ -1449,6 +1477,10 @@ bitflags! {
     }
 }
 
+unsafe impl Encode for MTLPipelineOption {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlaccelerationstructuresizes>
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[repr(C)]
@@ -1456,6 +1488,17 @@ pub struct MTLAccelerationStructureSizes {
     pub acceleration_structure_size: NSUInteger,
     pub build_scratch_buffer_size: NSUInteger,
     pub refit_scratch_buffer_size: NSUInteger,
+}
+
+unsafe impl Encode for MTLAccelerationStructureSizes {
+    const ENCODING: Encoding = Encoding::Struct(
+        "?",
+        &[
+            NSUInteger::ENCODING,
+            NSUInteger::ENCODING,
+            NSUInteger::ENCODING,
+        ],
+    );
 }
 
 #[cfg_attr(feature = "link", link(name = "Metal", kind = "framework"))]

--- a/src/drawable.rs
+++ b/src/drawable.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use super::NSUInteger;
+use super::*;
 
 /// See <https://developer.apple.com/documentation/metal/mtldrawable>
 pub enum MTLDrawable {}

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1265,9 +1265,10 @@ impl RenderCommandEncoderRef {
     pub fn execute_commands_in_buffer(
         &self,
         buffer: &IndirectCommandBufferRef,
-        with_range: NSRange,
+        range: Range<usize>,
     ) {
-        unsafe { msg_send![self, executeCommandsInBuffer:buffer withRange:with_range] }
+        let range: NSRange = range.into();
+        unsafe { msg_send![self, executeCommandsInBuffer:buffer withRange: range] }
     }
 
     pub fn update_fence(&self, fence: &FenceRef, after_stages: MTLRenderStages) {
@@ -1319,7 +1320,8 @@ impl BlitCommandEncoderRef {
         unsafe { msg_send![self, synchronizeResource: resource] }
     }
 
-    pub fn fill_buffer(&self, destination_buffer: &BufferRef, range: NSRange, value: u8) {
+    pub fn fill_buffer(&self, destination_buffer: &BufferRef, range: Range<usize>, value: u8) {
+        let range: NSRange = range.into();
         unsafe {
             msg_send![self,
                 fillBuffer: destination_buffer
@@ -1487,10 +1489,11 @@ impl BlitCommandEncoderRef {
     pub fn copy_indirect_command_buffer(
         &self,
         source: &IndirectCommandBufferRef,
-        source_range: NSRange,
+        source_range: Range<usize>,
         destination: &IndirectCommandBufferRef,
         destination_index: NSUInteger,
     ) {
+        let source_range: NSRange = source_range.into();
         unsafe {
             msg_send![self,
                 copyIndirectCommandBuffer: source
@@ -1501,7 +1504,8 @@ impl BlitCommandEncoderRef {
         }
     }
 
-    pub fn reset_commands_in_buffer(&self, buffer: &IndirectCommandBufferRef, range: NSRange) {
+    pub fn reset_commands_in_buffer(&self, buffer: &IndirectCommandBufferRef, range: Range<usize>) {
+        let range: NSRange = range.into();
         unsafe {
             msg_send![self,
                 resetCommandsInBuffer: buffer
@@ -1513,8 +1517,9 @@ impl BlitCommandEncoderRef {
     pub fn optimize_indirect_command_buffer(
         &self,
         buffer: &IndirectCommandBufferRef,
-        range: NSRange,
+        range: Range<usize>,
     ) {
+        let range: NSRange = range.into();
         unsafe {
             msg_send![self,
                 optimizeIndirectCommandBuffer: buffer
@@ -1543,10 +1548,11 @@ impl BlitCommandEncoderRef {
     pub fn resolve_counters(
         &self,
         sample_buffer: &CounterSampleBufferRef,
-        range: crate::NSRange,
+        range: Range<usize>,
         destination_buffer: &BufferRef,
         destination_offset: NSUInteger,
     ) {
+        let range: NSRange = range.into();
         unsafe {
             msg_send![self,
                 resolveCounters: sample_buffer

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1319,7 +1319,7 @@ impl BlitCommandEncoderRef {
         unsafe { msg_send![self, synchronizeResource: resource] }
     }
 
-    pub fn fill_buffer(&self, destination_buffer: &BufferRef, range: crate::NSRange, value: u8) {
+    pub fn fill_buffer(&self, destination_buffer: &BufferRef, range: NSRange, value: u8) {
         unsafe {
             msg_send![self,
                 fillBuffer: destination_buffer

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -23,6 +23,10 @@ pub enum MTLPrimitiveType {
     TriangleStrip = 4,
 }
 
+unsafe impl Encode for MTLPrimitiveType {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlindextype>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -30,6 +34,10 @@ pub enum MTLPrimitiveType {
 pub enum MTLIndexType {
     UInt16 = 0,
     UInt32 = 1,
+}
+
+unsafe impl Encode for MTLIndexType {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlvisibilityresultmode>
@@ -41,6 +49,10 @@ pub enum MTLVisibilityResultMode {
     Counting = 2,
 }
 
+unsafe impl Encode for MTLVisibilityResultMode {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlcullmode>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -48,6 +60,10 @@ pub enum MTLCullMode {
     None = 0,
     Front = 1,
     Back = 2,
+}
+
+unsafe impl Encode for MTLCullMode {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlwinding>
@@ -58,6 +74,10 @@ pub enum MTLWinding {
     CounterClockwise = 1,
 }
 
+unsafe impl Encode for MTLWinding {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtldepthclipmode>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -66,12 +86,20 @@ pub enum MTLDepthClipMode {
     Clamp = 1,
 }
 
+unsafe impl Encode for MTLDepthClipMode {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtltrianglefillmode>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLTriangleFillMode {
     Fill = 0,
     Lines = 1,
+}
+
+unsafe impl Encode for MTLTriangleFillMode {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 bitflags! {
@@ -90,6 +118,10 @@ bitflags! {
     }
 }
 
+unsafe impl Encode for MTLBlitOption {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlscissorrect>
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
@@ -98,6 +130,18 @@ pub struct MTLScissorRect {
     pub y: NSUInteger,
     pub width: NSUInteger,
     pub height: NSUInteger,
+}
+
+unsafe impl Encode for MTLScissorRect {
+    const ENCODING: Encoding = Encoding::Struct(
+        "MTLScissorRect",
+        &[
+            NSUInteger::ENCODING,
+            NSUInteger::ENCODING,
+            NSUInteger::ENCODING,
+            NSUInteger::ENCODING,
+        ],
+    );
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlviewport>
@@ -110,6 +154,20 @@ pub struct MTLViewport {
     pub height: f64,
     pub znear: f64,
     pub zfar: f64,
+}
+
+unsafe impl Encode for MTLViewport {
+    const ENCODING: Encoding = Encoding::Struct(
+        "MTLViewport",
+        &[
+            f64::ENCODING,
+            f64::ENCODING,
+            f64::ENCODING,
+            f64::ENCODING,
+            f64::ENCODING,
+            f64::ENCODING,
+        ],
+    );
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtldrawprimitivesindirectarguments>
@@ -139,6 +197,17 @@ pub struct MTLDrawIndexedPrimitivesIndirectArguments {
 pub struct VertexAmplificationViewMapping {
     pub renderTargetArrayIndexOffset: u32,
     pub viewportArrayIndexOffset: u32,
+}
+
+unsafe impl Encode for VertexAmplificationViewMapping {
+    const ENCODING: Encoding = Encoding::Struct(
+        "VertexAmplificationViewMapping",
+        &[u32::ENCODING, u32::ENCODING],
+    );
+}
+
+unsafe impl RefEncode for VertexAmplificationViewMapping {
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 }
 
 #[allow(dead_code)]

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -134,7 +134,7 @@ pub struct MTLScissorRect {
 
 unsafe impl Encode for MTLScissorRect {
     const ENCODING: Encoding = Encoding::Struct(
-        "MTLScissorRect",
+        "?",
         &[
             NSUInteger::ENCODING,
             NSUInteger::ENCODING,
@@ -158,7 +158,7 @@ pub struct MTLViewport {
 
 unsafe impl Encode for MTLViewport {
     const ENCODING: Encoding = Encoding::Struct(
-        "MTLViewport",
+        "?",
         &[
             f64::ENCODING,
             f64::ENCODING,
@@ -201,7 +201,7 @@ pub struct VertexAmplificationViewMapping {
 
 unsafe impl Encode for VertexAmplificationViewMapping {
     const ENCODING: Encoding = Encoding::Struct(
-        "VertexAmplificationViewMapping",
+        "?",
         &[u32::ENCODING, u32::ENCODING],
     );
 }

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -19,6 +19,10 @@ pub enum MTLHeapType {
     Sparse = 2,
 }
 
+unsafe impl Encode for MTLHeapType {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlheap/>
 pub enum MTLHeap {}
 

--- a/src/indirect_encoder.rs
+++ b/src/indirect_encoder.rs
@@ -108,7 +108,7 @@ impl IndirectCommandBufferRef {
         unsafe { msg_send![self, indirectComputeCommandAtIndex: index] }
     }
 
-    pub fn reset_with_range(&self, range: crate::NSRange) {
+    pub fn reset_with_range(&self, range: NSRange) {
         unsafe { msg_send![self, resetWithRange: range] }
     }
 }

--- a/src/indirect_encoder.rs
+++ b/src/indirect_encoder.rs
@@ -108,7 +108,8 @@ impl IndirectCommandBufferRef {
         unsafe { msg_send![self, indirectComputeCommandAtIndex: index] }
     }
 
-    pub fn reset_with_range(&self, range: NSRange) {
+    pub fn reset_with_range(&self, range: Range<usize>) {
+        let range: NSRange = range.into();
         unsafe { msg_send![self, resetWithRange: range] }
     }
 }

--- a/src/indirect_encoder.rs
+++ b/src/indirect_encoder.rs
@@ -14,6 +14,10 @@ bitflags! {
     }
 }
 
+unsafe impl Encode for MTLIndirectCommandType {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlindirectcommandbufferdescriptor/>
 pub enum MTLIndirectCommandBufferDescriptor {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,46 +28,10 @@ use std::{
     os::raw::c_void,
 };
 
-use core_graphics_types::{base::CGFloat, geometry::CGSize};
 use foreign_types::ForeignType;
 pub(crate) use objc2::encode::{Encode, Encoding, RefEncode};
+pub use objc2::foundation::{CGFloat, NSInteger, NSRange, NSSize as CGSize, NSUInteger};
 use objc2::runtime::{Bool, Object, Protocol};
-
-/// See <https://developer.apple.com/documentation/objectivec/nsinteger>
-#[cfg(target_pointer_width = "64")]
-pub type NSInteger = i64;
-
-/// See <https://developer.apple.com/documentation/objectivec/nsinteger>
-#[cfg(not(target_pointer_width = "64"))]
-pub type NSInteger = i32;
-
-/// See <https://developer.apple.com/documentation/objectivec/nsuinteger>
-#[cfg(target_pointer_width = "64")]
-pub type NSUInteger = u64;
-
-/// See <https://developer.apple.com/documentation/objectivec/nsuinteger>
-#[cfg(target_pointer_width = "32")]
-pub type NSUInteger = u32;
-
-/// See <https://developer.apple.com/documentation/foundation/nsrange>
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct NSRange {
-    pub location: NSUInteger,
-    pub length: NSUInteger,
-}
-
-unsafe impl objc2::Encode for NSRange {
-    const ENCODING: objc2::Encoding =
-        objc2::Encoding::Struct("_NSRange", &[NSUInteger::ENCODING, NSUInteger::ENCODING]);
-}
-
-impl NSRange {
-    #[inline]
-    pub fn new(location: NSUInteger, length: NSUInteger) -> NSRange {
-        NSRange { location, length }
-    }
-}
 
 fn nsstring_as_str(nsstr: &Object) -> &str {
     let bytes = unsafe {
@@ -76,7 +40,7 @@ fn nsstring_as_str(nsstr: &Object) -> &str {
     };
     let len: NSUInteger = unsafe { msg_send![nsstr, length] };
     unsafe {
-        let bytes = std::slice::from_raw_parts(bytes, len as usize);
+        let bytes = std::slice::from_raw_parts(bytes, len);
         std::str::from_utf8(bytes).unwrap()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,8 @@ use std::{
 };
 
 use foreign_types::ForeignType;
-pub use icrate::Foundation::NSSize as CGSize;
-pub(crate) use icrate::Foundation::{CGFloat, NSRange};
-pub(crate) use objc2::encode::{Encode, Encoding, RefEncode};
+use icrate::Foundation::{CGFloat, CGSize, NSRange};
+use objc2::encode::{Encode, Encoding, RefEncode};
 use objc2::runtime::{AnyObject, Bool, Protocol};
 
 // Explicitly doesn't use `icrate::Foundation::NS[U]Integer`, so that the
@@ -449,11 +448,13 @@ impl MetalLayerRef {
         unsafe { msg_send![self, setPixelFormat: pixel_format] }
     }
 
-    pub fn drawable_size(&self) -> CGSize {
-        unsafe { msg_send![self, drawableSize] }
+    pub fn drawable_size(&self) -> (f64, f64) {
+        let res: CGSize = unsafe { msg_send![self, drawableSize] };
+        (res.width as _, res.height as _)
     }
 
-    pub fn set_drawable_size(&self, size: CGSize) {
+    pub fn set_drawable_size(&self, width: f64, height: f64) {
+        let size = CGSize::new(width as _, height as _);
         unsafe { msg_send![self, setDrawableSize: size] }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@ use std::{
 };
 
 use foreign_types::ForeignType;
-pub(crate) use icrate::Foundation::NSRange;
-pub use icrate::Foundation::{CGFloat, NSSize as CGSize};
+pub use icrate::Foundation::NSSize as CGSize;
+pub(crate) use icrate::Foundation::{CGFloat, NSRange};
 pub(crate) use objc2::encode::{Encode, Encoding, RefEncode};
 use objc2::runtime::{AnyObject, Bool, Protocol};
 
@@ -497,11 +497,13 @@ impl MetalLayerRef {
         unsafe { msg_send![self, nextDrawable] }
     }
 
-    pub fn contents_scale(&self) -> CGFloat {
-        unsafe { msg_send![self, contentsScale] }
+    pub fn contents_scale(&self) -> f64 {
+        let res: CGFloat = unsafe { msg_send![self, contentsScale] };
+        res as f64
     }
 
-    pub fn set_contents_scale(&self, scale: CGFloat) {
+    pub fn set_contents_scale(&self, scale: f64) {
+        let scale = scale as CGFloat;
         unsafe { msg_send![self, setContentsScale: scale] }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,12 +24,13 @@ use std::{
     borrow::{Borrow, ToOwned},
     marker::PhantomData,
     mem,
-    ops::Deref,
+    ops::{Deref, Range},
     os::raw::c_void,
 };
 
 use foreign_types::ForeignType;
-pub use icrate::Foundation::{CGFloat, NSRange, NSSize as CGSize};
+pub(crate) use icrate::Foundation::NSRange;
+pub use icrate::Foundation::{CGFloat, NSSize as CGSize};
 pub(crate) use objc2::encode::{Encode, Encoding, RefEncode};
 use objc2::runtime::{AnyObject, Bool, Protocol};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,14 @@ use std::{
 };
 
 use foreign_types::ForeignType;
-pub use icrate::Foundation::{CGFloat, NSInteger, NSRange, NSSize as CGSize, NSUInteger};
+pub use icrate::Foundation::{CGFloat, NSRange, NSSize as CGSize};
 pub(crate) use objc2::encode::{Encode, Encoding, RefEncode};
 use objc2::runtime::{AnyObject, Bool, Protocol};
+
+// Explicitly doesn't use `icrate::Foundation::NS[U]Integer`, so that the
+// documentation will just show the simple Rust type.
+pub(crate) type NSInteger = isize;
+pub(crate) type NSUInteger = usize;
 
 fn nsstring_as_str(nsstr: &AnyObject) -> &str {
     let bytes = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@ use std::{
 };
 
 use foreign_types::ForeignType;
+pub use icrate::Foundation::{CGFloat, NSInteger, NSRange, NSSize as CGSize, NSUInteger};
 pub(crate) use objc2::encode::{Encode, Encoding, RefEncode};
-pub use objc2::foundation::{CGFloat, NSInteger, NSRange, NSSize as CGSize, NSUInteger};
 use objc2::runtime::{Bool, Object, Protocol};
 
 fn nsstring_as_str(nsstr: &Object) -> &str {

--- a/src/library.rs
+++ b/src/library.rs
@@ -426,7 +426,7 @@ impl FunctionConstantValuesRef {
 /// Only available on (macos(11.0), ios(14.0))
 ///
 /// See <https://developer.apple.com/documentation/metal/mtllibrarytype/>
-#[repr(u64)]
+#[repr(isize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLLibraryType {
     Executable = 0,
@@ -434,7 +434,7 @@ pub enum MTLLibraryType {
 }
 
 unsafe impl Encode for MTLLibraryType {
-    const ENCODING: Encoding = u64::ENCODING;
+    const ENCODING: Encoding = isize::ENCODING;
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlcompileoptions/>

--- a/src/library.rs
+++ b/src/library.rs
@@ -321,12 +321,12 @@ impl FunctionRef {
     }
 
     /// Only available on (macos(10.12), ios(10.0))
-    pub fn vertex_attributes(&self) -> &Array<VertexAttribute> {
+    pub fn vertex_attributes(&self) -> &ArrayRef<VertexAttribute> {
         unsafe { msg_send![self, vertexAttributes] }
     }
 
     /// Only available on (macos(10.12), ios(10.0))
-    pub fn stage_input_attributes(&self) -> &Array<Attribute> {
+    pub fn stage_input_attributes(&self) -> &ArrayRef<Attribute> {
         unsafe { msg_send![self, stageInputAttributes] }
     }
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -409,8 +409,9 @@ impl FunctionConstantValuesRef {
         &self,
         values: *const c_void,
         ty: MTLDataType,
-        range: NSRange,
+        range: Range<usize>,
     ) {
+        let range: NSRange = range.into();
         unsafe { msg_send![self, setConstantValues:values type:ty withRange:range] }
     }
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -8,7 +8,6 @@
 use super::*;
 
 use foreign_types::ForeignType;
-use objc2::runtime::Object;
 
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
@@ -349,7 +348,7 @@ impl FunctionRef {
         }
     }
 
-    pub fn function_constants_dictionary(&self) -> *mut Object {
+    pub fn function_constants_dictionary(&self) -> *mut AnyObject {
         unsafe { msg_send![self, functionConstantsDictionary] }
     }
 
@@ -455,11 +454,11 @@ impl CompileOptions {
 }
 
 impl CompileOptionsRef {
-    pub unsafe fn preprocessor_macros(&self) -> *mut Object {
+    pub unsafe fn preprocessor_macros(&self) -> *mut AnyObject {
         msg_send![self, preprocessorMacros]
     }
 
-    pub unsafe fn set_preprocessor_macros(&self, defines: *mut Object) {
+    pub unsafe fn set_preprocessor_macros(&self, defines: *mut AnyObject) {
         msg_send![self, setPreprocessorMacros: defines]
     }
 
@@ -512,7 +511,7 @@ impl CompileOptionsRef {
     /// Marshal to Rust Vec
     pub fn libraries(&self) -> Vec<DynamicLibrary> {
         unsafe {
-            let libraries: *mut Object = msg_send![self, libraries];
+            let libraries: *mut AnyObject = msg_send![self, libraries];
             let count: NSUInteger = msg_send![libraries, count];
             let ret = (0..count)
                 .map(|i| {
@@ -632,7 +631,7 @@ impl LibraryRef {
 
     pub fn function_names(&self) -> Vec<String> {
         unsafe {
-            let names: *mut Object = msg_send![self, functionNames];
+            let names: *mut AnyObject = msg_send![self, functionNames];
             let count: NSUInteger = msg_send![names, count];
             let ret = (0..count)
                 .map(|i| {
@@ -652,7 +651,7 @@ impl LibraryRef {
     /// Only available on (macos(11.0), ios(14.0))
     pub fn install_name(&self) -> Option<&str> {
         unsafe {
-            let maybe_name: *mut Object = msg_send![self, installName];
+            let maybe_name: *mut AnyObject = msg_send![self, installName];
             maybe_name.as_ref().map(crate::nsstring_as_str)
         }
     }
@@ -866,7 +865,7 @@ impl LinkedFunctionsRef {
     /// Marshal to Rust Vec
     pub fn functions(&self) -> Vec<Function> {
         unsafe {
-            let functions: *mut Object = msg_send![self, functions];
+            let functions: *mut AnyObject = msg_send![self, functions];
             let count: NSUInteger = msg_send![functions, count];
             let ret = (0..count)
                 .map(|i| {
@@ -887,7 +886,7 @@ impl LinkedFunctionsRef {
     /// Marshal to Rust Vec
     pub fn binary_functions(&self) -> Vec<Function> {
         unsafe {
-            let functions: *mut Object = msg_send![self, binaryFunctions];
+            let functions: *mut AnyObject = msg_send![self, binaryFunctions];
             let count: NSUInteger = msg_send![functions, count];
             let ret = (0..count)
                 .map(|i| {

--- a/src/mps.rs
+++ b/src/mps.rs
@@ -7,19 +7,21 @@
 
 use super::*;
 
-use objc::runtime::{BOOL, YES};
+use objc2::runtime::Bool;
 
-#[cfg_attr(feature = "link", link(name = "MetalPerformanceShaders", kind = "framework"))]
+#[cfg_attr(
+    feature = "link",
+    link(name = "MetalPerformanceShaders", kind = "framework")
+)]
 extern "C" {
-    fn MPSSupportsMTLDevice(device: *const std::ffi::c_void) -> BOOL;
+    fn MPSSupportsMTLDevice(device: *const std::ffi::c_void) -> Bool;
 }
 
 pub fn mps_supports_device(device: &DeviceRef) -> bool {
-    let b: BOOL = unsafe {
+    unsafe {
         let ptr: *const DeviceRef = device;
-        MPSSupportsMTLDevice(ptr as _)
-    };
-    b == YES
+        MPSSupportsMTLDevice(ptr as _).as_bool()
+    }
 }
 
 /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpskernel>
@@ -31,10 +33,15 @@ foreign_obj_type! {
 }
 
 /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsraydatatype>
+#[repr(usize)] // NSUInteger
 pub enum MPSRayDataType {
     OriginDirection = 0,
     OriginMinDistanceDirectionMaxDistance = 1,
     OriginMaskDirectionMaxDistance = 2,
+}
+
+unsafe impl Encode for MPSRayDataType {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
 }
 
 bitflags! {
@@ -49,9 +56,14 @@ bitflags! {
     }
 }
 
+unsafe impl Encode for MPSRayMaskOptions {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
+}
+
 /// Options that determine the data contained in an intersection result.
 ///
 /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsintersectiondatatype>
+#[repr(usize)] // NSUInteger
 pub enum MPSIntersectionDataType {
     Distance = 0,
     DistancePrimitiveIndex = 1,
@@ -60,7 +72,12 @@ pub enum MPSIntersectionDataType {
     DistancePrimitiveIndexInstanceIndexCoordinates = 4,
 }
 
+unsafe impl Encode for MPSIntersectionDataType {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsintersectiontype>
+#[repr(usize)] // NSUInteger
 pub enum MPSIntersectionType {
     /// Find the closest intersection to the ray's origin along the ray direction.
     /// This is potentially slower than `Any` but is well suited to primary visibility rays.
@@ -70,7 +87,12 @@ pub enum MPSIntersectionType {
     Any = 1,
 }
 
+unsafe impl Encode for MPSIntersectionType {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsraymaskoperator>
+#[repr(usize)] // NSUInteger
 pub enum MPSRayMaskOperator {
     /// Accept the intersection if `(primitive mask & ray mask) != 0`.
     And = 0,
@@ -96,7 +118,12 @@ pub enum MPSRayMaskOperator {
     GreaterThanOrEqualTo = 9,
 }
 
+unsafe impl Encode for MPSRayMaskOperator {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpstriangleintersectiontesttype>
+#[repr(usize)] // NSUInteger
 pub enum MPSTriangleIntersectionTestType {
     /// Use the default ray/triangle intersection test
     Default = 0,
@@ -106,11 +133,20 @@ pub enum MPSTriangleIntersectionTestType {
     Watertight = 1,
 }
 
+unsafe impl Encode for MPSTriangleIntersectionTestType {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsaccelerationstructurestatus>
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[repr(usize)] // NSUInteger
 pub enum MPSAccelerationStructureStatus {
     Unbuilt = 0,
     Built = 1,
+}
+
+unsafe impl Encode for MPSAccelerationStructureStatus {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
 }
 
 bitflags! {
@@ -129,12 +165,17 @@ bitflags! {
     }
 }
 
+unsafe impl Encode for MPSAccelerationStructureUsage {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
+}
+
 /// A common bit for all floating point data types.
-const MPSDataTypeFloatBit: isize = 0x10000000;
-const MPSDataTypeSignedBit: isize = 0x20000000;
-const MPSDataTypeNormalizedBit: isize = 0x40000000;
+const MPSDataTypeFloatBit: u32 = 0x10000000;
+const MPSDataTypeSignedBit: u32 = 0x20000000;
+const MPSDataTypeNormalizedBit: u32 = 0x40000000;
 
 /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsdatatype>
+#[repr(u32)] // uint32_t
 pub enum MPSDataType {
     Invalid = 0,
 
@@ -154,6 +195,10 @@ pub enum MPSDataType {
     // Unsigned normalized. Range: [0, 1.0]
     Unorm1 = MPSDataTypeNormalizedBit | 1,
     Unorm8 = MPSDataTypeNormalizedBit | 8,
+}
+
+unsafe impl Encode for MPSDataType {
+    const ENCODING: Encoding = u32::ENCODING;
 }
 
 /// A kernel that performs intersection tests between rays and geometry.
@@ -412,6 +457,10 @@ impl TriangleAccelerationStructureRef {
 pub enum MPSTransformType {
     Float4x4 = 0,
     Identity = 1,
+}
+
+unsafe impl Encode for MPSTransformType {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 /// An acceleration structure built over instances of other acceleration structures

--- a/src/mps.rs
+++ b/src/mps.rs
@@ -216,7 +216,7 @@ impl RayIntersector {
     pub fn from_device(device: &DeviceRef) -> Option<Self> {
         unsafe {
             let intersector: RayIntersector = msg_send![class!(MPSRayIntersector), alloc];
-            let ptr: *mut Object = msg_send![intersector.as_ref(), initWithDevice: device];
+            let ptr: *mut AnyObject = msg_send![intersector.as_ref(), initWithDevice: device];
             if ptr.is_null() {
                 None
             } else {
@@ -320,7 +320,7 @@ impl AccelerationStructureGroup {
         unsafe {
             let group: AccelerationStructureGroup =
                 msg_send![class!(MPSAccelerationStructureGroup), alloc];
-            let ptr: *mut Object = msg_send![group.as_ref(), initWithDevice: device];
+            let ptr: *mut AnyObject = msg_send![group.as_ref(), initWithDevice: device];
             if ptr.is_null() {
                 None
             } else {
@@ -431,7 +431,7 @@ impl TriangleAccelerationStructure {
         unsafe {
             let structure: TriangleAccelerationStructure =
                 msg_send![class!(MPSTriangleAccelerationStructure), alloc];
-            let ptr: *mut Object = msg_send![structure.as_ref(), initWithDevice: device];
+            let ptr: *mut AnyObject = msg_send![structure.as_ref(), initWithDevice: device];
             if ptr.is_null() {
                 None
             } else {
@@ -479,7 +479,7 @@ impl InstanceAccelerationStructure {
         unsafe {
             let structure: InstanceAccelerationStructure =
                 msg_send![class!(MPSInstanceAccelerationStructure), alloc];
-            let ptr: *mut Object = msg_send![structure.as_ref(), initWithGroup: group];
+            let ptr: *mut AnyObject = msg_send![structure.as_ref(), initWithGroup: group];
             if ptr.is_null() {
                 None
             } else {
@@ -493,7 +493,7 @@ impl InstanceAccelerationStructureRef {
     /// Marshal to Rust Vec
     pub fn acceleration_structures(&self) -> Vec<PolygonAccelerationStructure> {
         unsafe {
-            let acs: *mut Object = msg_send![self, accelerationStructures];
+            let acs: *mut AnyObject = msg_send![self, accelerationStructures];
             let count: NSUInteger = msg_send![acs, count];
             let ret = (0..count)
                 .map(|i| {

--- a/src/pipeline/compute.rs
+++ b/src/pipeline/compute.rs
@@ -190,7 +190,7 @@ impl ComputePipelineDescriptorRef {
     /// Marshal to Rust Vec
     pub fn insert_libraries(&self) -> Vec<DynamicLibrary> {
         unsafe {
-            let libraries: *mut Object = msg_send![self, insertLibraries];
+            let libraries: *mut AnyObject = msg_send![self, insertLibraries];
             let count: NSUInteger = msg_send![libraries, count];
             let ret = (0..count)
                 .map(|i| {
@@ -212,7 +212,7 @@ impl ComputePipelineDescriptorRef {
     /// Marshal to Rust Vec
     pub fn binary_archives(&self) -> Vec<BinaryArchive> {
         unsafe {
-            let archives: *mut Object = msg_send![self, binaryArchives];
+            let archives: *mut AnyObject = msg_send![self, binaryArchives];
             let count: NSUInteger = msg_send![archives, count];
             let ret = (0..count)
                 .map(|i| {

--- a/src/pipeline/compute.rs
+++ b/src/pipeline/compute.rs
@@ -7,8 +7,6 @@
 
 use super::*;
 
-use objc::runtime::{NO, YES};
-
 /// See <https://developer.apple.com/documentation/metal/mtlattributeformat>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -68,6 +66,10 @@ pub enum MTLAttributeFormat {
     Half = 53,
 }
 
+unsafe impl Encode for MTLAttributeFormat {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlstepfunction>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -82,6 +84,10 @@ pub enum MTLStepFunction {
     ThreadPositionInGridXIndexed = 6,
     ThreadPositionInGridY = 7,
     ThreadPositionInGridYIndexed = 8,
+}
+
+unsafe impl Encode for MTLStepFunction {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlcomputepipelinedescriptor>

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -23,6 +23,10 @@ pub enum MTLMutability {
     Immutable = 2,
 }
 
+unsafe impl Encode for MTLMutability {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 impl Default for MTLMutability {
     #[inline]
     fn default() -> Self {

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -7,8 +7,6 @@
 
 use super::*;
 
-use objc::runtime::{NO, YES};
-
 /// See <https://developer.apple.com/documentation/metal/mtlblendfactor>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -35,6 +33,10 @@ pub enum MTLBlendFactor {
     OneMinusSource1Alpha = 18,
 }
 
+unsafe impl Encode for MTLBlendFactor {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlblendoperation>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -45,6 +47,10 @@ pub enum MTLBlendOperation {
     ReverseSubtract = 2,
     Min = 3,
     Max = 4,
+}
+
+unsafe impl Encode for MTLBlendOperation {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 bitflags! {
@@ -60,6 +66,10 @@ bitflags! {
     }
 }
 
+unsafe impl Encode for MTLColorWriteMask {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlprimitivetopologyclass>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -69,6 +79,10 @@ pub enum MTLPrimitiveTopologyClass {
     Point = 1,
     Line = 2,
     Triangle = 3,
+}
+
+unsafe impl Encode for MTLPrimitiveTopologyClass {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 // TODO: MTLTessellationPartitionMode

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -192,7 +192,7 @@ impl RenderPipelineReflection {
     ) -> Self {
         let class = class!(MTLRenderPipelineReflection);
         let this: RenderPipelineReflection = msg_send![class, alloc];
-        let this_alias: *mut Object = msg_send![this.as_ref(), initWithVertexData:vertex_data
+        let this_alias: *mut AnyObject = msg_send![this.as_ref(), initWithVertexData:vertex_data
                                                                 fragmentData:fragment_data
                                                 serializedVertexDescriptor:vertex_desc
                                                                     device:device
@@ -627,7 +627,7 @@ impl RenderPipelineDescriptorRef {
     pub unsafe fn serialize_vertex_data(&self) -> *mut std::ffi::c_void {
         use std::ptr;
         let flags = 0;
-        let err: *mut Object = ptr::null_mut();
+        let err: *mut AnyObject = ptr::null_mut();
         msg_send![self, newSerializedVertexDataWithFlags:flags
                                                     error:err]
     }
@@ -659,7 +659,7 @@ impl RenderPipelineDescriptorRef {
     /// Marshal to Rust Vec
     pub fn binary_archives(&self) -> Vec<BinaryArchive> {
         unsafe {
-            let archives: *mut Object = msg_send![self, binaryArchives];
+            let archives: *mut AnyObject = msg_send![self, binaryArchives];
             let count: NSUInteger = msg_send![archives, count];
             let ret = (0..count)
                 .map(|i| {

--- a/src/renderpass.rs
+++ b/src/renderpass.rs
@@ -16,6 +16,10 @@ pub enum MTLLoadAction {
     Clear = 2,
 }
 
+unsafe impl Encode for MTLLoadAction {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlstoreaction>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug)]
@@ -28,6 +32,10 @@ pub enum MTLStoreAction {
     CustomSampleDepthStore = 5,
 }
 
+unsafe impl Encode for MTLStoreAction {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlclearcolor>
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
@@ -36,6 +44,13 @@ pub struct MTLClearColor {
     pub green: f64,
     pub blue: f64,
     pub alpha: f64,
+}
+
+unsafe impl Encode for MTLClearColor {
+    const ENCODING: Encoding = Encoding::Struct(
+        "MTLClearColor",
+        &[f64::ENCODING, f64::ENCODING, f64::ENCODING, f64::ENCODING],
+    );
 }
 
 impl MTLClearColor {
@@ -56,6 +71,10 @@ impl MTLClearColor {
 pub enum MTLMultisampleStencilResolveFilter {
     Sample0 = 0,
     DepthResolvedSample = 1,
+}
+
+unsafe impl Encode for MTLMultisampleStencilResolveFilter {
+    const ENCODING: Encoding = u32::ENCODING;
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlrenderpassattachmentdescriptor>

--- a/src/renderpass.rs
+++ b/src/renderpass.rs
@@ -48,7 +48,7 @@ pub struct MTLClearColor {
 
 unsafe impl Encode for MTLClearColor {
     const ENCODING: Encoding = Encoding::Struct(
-        "MTLClearColor",
+        "?",
         &[f64::ENCODING, f64::ENCODING, f64::ENCODING, f64::ENCODING],
     );
 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -130,7 +130,7 @@ pub struct MTLSizeAndAlign {
 
 unsafe impl Encode for MTLSizeAndAlign {
     const ENCODING: Encoding = Encoding::Struct(
-        "MTLSizeAndAlign",
+        "?",
         &[NSUInteger::ENCODING, NSUInteger::ENCODING],
     );
 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use super::*;
-use objc::runtime::{NO, YES};
 
 /// See <https://developer.apple.com/documentation/metal/mtlpurgeablestate>
 #[repr(u64)]
@@ -18,12 +17,20 @@ pub enum MTLPurgeableState {
     Empty = 4,
 }
 
+unsafe impl Encode for MTLPurgeableState {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlcpucachemode>
 #[repr(u64)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLCPUCacheMode {
     DefaultCache = 0,
     WriteCombined = 1,
+}
+
+unsafe impl Encode for MTLCPUCacheMode {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlstoragemode>
@@ -37,6 +44,10 @@ pub enum MTLStorageMode {
     Memoryless = 3,
 }
 
+unsafe impl Encode for MTLStorageMode {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// Only available on macos(10.15), ios(13.0)
 ///
 /// See <https://developer.apple.com/documentation/metal/mtlhazardtrackingmode>
@@ -46,6 +57,10 @@ pub enum MTLHazardTrackingMode {
     Default = 0,
     Untracked = 1,
     Tracked = 2,
+}
+
+unsafe impl Encode for MTLHazardTrackingMode {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 pub const MTLResourceCPUCacheModeShift: NSUInteger = 0;
@@ -77,6 +92,10 @@ bitflags! {
     }
 }
 
+unsafe impl Encode for MTLResourceOptions {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
+}
+
 bitflags! {
     /// Options that describe how a graphics or compute function uses an argument buffer’s resource.
     ///
@@ -97,12 +116,23 @@ bitflags! {
     }
 }
 
+unsafe impl Encode for MTLResourceUsage {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlsizeandalign>
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[repr(C)]
 pub struct MTLSizeAndAlign {
     pub size: NSUInteger,
     pub align: NSUInteger,
+}
+
+unsafe impl Encode for MTLSizeAndAlign {
+    const ENCODING: Encoding = Encoding::Struct(
+        "MTLSizeAndAlign",
+        &[NSUInteger::ENCODING, NSUInteger::ENCODING],
+    );
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlresource>

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use super::{depthstencil::MTLCompareFunction, DeviceRef, NSUInteger};
+use super::{depthstencil::MTLCompareFunction, *};
 
 /// See <https://developer.apple.com/documentation/metal/mtlsamplerminmagfilter>
 #[repr(u64)]
@@ -15,6 +15,10 @@ pub enum MTLSamplerMinMagFilter {
     Linear = 1,
 }
 
+unsafe impl Encode for MTLSamplerMinMagFilter {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlsamplermipfilter>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -22,6 +26,10 @@ pub enum MTLSamplerMipFilter {
     NotMipmapped = 0,
     Nearest = 1,
     Linear = 2,
+}
+
+unsafe impl Encode for MTLSamplerMipFilter {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlsampleraddressmode>
@@ -36,6 +44,10 @@ pub enum MTLSamplerAddressMode {
     ClampToBorderColor = 5,
 }
 
+unsafe impl Encode for MTLSamplerAddressMode {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlsamplerbordercolor>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -43,6 +55,10 @@ pub enum MTLSamplerBorderColor {
     TransparentBlack = 0,
     OpaqueBlack = 1,
     OpaqueWhite = 2,
+}
+
+unsafe impl Encode for MTLSamplerBorderColor {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlsamplerdescriptor>

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -7,7 +7,6 @@
 
 use super::*;
 use block2::{Block, RcBlock};
-use objc2::encode::EncodeArguments;
 use std::mem;
 
 #[cfg(feature = "dispatch_queue")]
@@ -173,7 +172,7 @@ struct BlockBase<A, R> {
 
 type BlockExtraDtor<A, R> = extern "C" fn(*mut BlockBase<A, R>);
 
-unsafe impl<A: EncodeArguments, R: Encode> RefEncode for BlockBase<A, R> {
+unsafe impl RefEncode for BlockBase<(&SharedEventRef, u64), ()> {
     const ENCODING_REF: Encoding = Encoding::Block;
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -6,7 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 
 use super::*;
-use block::{Block, RcBlock};
+use block2::{Block, RcBlock};
+use objc2::encode::EncodeArguments;
 use std::mem;
 
 #[cfg(feature = "dispatch_queue")]
@@ -154,6 +155,10 @@ bitflags! {
     }
 }
 
+unsafe impl Encode for MTLRenderStages {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 const BLOCK_HAS_COPY_DISPOSE: i32 = 0x02000000;
 const BLOCK_HAS_SIGNATURE: i32 = 0x40000000;
 
@@ -167,6 +172,10 @@ struct BlockBase<A, R> {
 }
 
 type BlockExtraDtor<A, R> = extern "C" fn(*mut BlockBase<A, R>);
+
+unsafe impl<A: EncodeArguments, R: Encode> RefEncode for BlockBase<A, R> {
+    const ENCODING_REF: Encoding = Encoding::Block;
+}
 
 #[repr(C)]
 struct BlockExtra<A, R> {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -92,7 +92,7 @@ foreign_obj_type! {
 impl SharedEventListener {
     pub unsafe fn from_queue_handle(queue: dispatch_queue_t) -> Self {
         let listener: SharedEventListener = msg_send![class!(MTLSharedEventListener), alloc];
-        let ptr: *mut Object = msg_send![listener.as_ref(), initWithDispatchQueue: queue];
+        let ptr: *mut AnyObject = msg_send![listener.as_ref(), initWithDispatchQueue: queue];
         if ptr.is_null() {
             panic!("[MTLSharedEventListener alloc] initWithDispatchQueue failed");
         }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -7,8 +7,6 @@
 
 use super::*;
 
-use objc::runtime::{NO, YES};
-
 /// See <https://developer.apple.com/documentation/metal/mtltexturetype>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
@@ -25,12 +23,20 @@ pub enum MTLTextureType {
     D2MultisampleArray = 8,
 }
 
+unsafe impl Encode for MTLTextureType {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtltexturecompressiontype>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum MTLTextureCompressionType {
     Lossless = 0,
     Lossy = 1,
+}
+
+unsafe impl Encode for MTLTextureCompressionType {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 bitflags! {
@@ -43,6 +49,10 @@ bitflags! {
         const RenderTarget    = 0x0004;
         const PixelFormatView = 0x0010;
     }
+}
+
+unsafe impl Encode for MTLTextureUsage {
+    const ENCODING: Encoding = NSUInteger::ENCODING;
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtltexturedescriptor>

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -344,9 +344,11 @@ impl TextureRef {
         &self,
         pixel_format: MTLPixelFormat,
         texture_type: MTLTextureType,
-        mipmap_levels: NSRange,
-        slices: NSRange,
+        mipmap_levels: Range<usize>,
+        slices: Range<usize>,
     ) -> Texture {
+        let mipmap_levels: NSRange = mipmap_levels.into();
+        let slices: NSRange = slices.into();
         unsafe {
             msg_send![self, newTextureViewWithPixelFormat:pixel_format
                                                 textureType:texture_type

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -127,7 +127,7 @@ impl TextureDescriptorRef {
             height,
             depth,
         } = size;
-        let count = (width.max(height).max(depth) as f64).log2().ceil() as u64;
+        let count = (width.max(height).max(depth) as f64).log2().ceil() as NSUInteger;
         self.set_mipmap_level_count(count);
     }
 
@@ -344,8 +344,8 @@ impl TextureRef {
         &self,
         pixel_format: MTLPixelFormat,
         texture_type: MTLTextureType,
-        mipmap_levels: crate::NSRange,
-        slices: crate::NSRange,
+        mipmap_levels: NSRange,
+        slices: NSRange,
     ) -> Texture {
         unsafe {
             msg_send![self, newTextureViewWithPixelFormat:pixel_format

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use super::NSUInteger;
+use super::*;
 use std::default::Default;
 
 /// See <https://developer.apple.com/documentation/metal/mtlorigin>
@@ -17,6 +17,17 @@ pub struct MTLOrigin {
     pub z: NSUInteger,
 }
 
+unsafe impl Encode for MTLOrigin {
+    const ENCODING: Encoding = Encoding::Struct(
+        "?",
+        &[
+            NSUInteger::ENCODING,
+            NSUInteger::ENCODING,
+            NSUInteger::ENCODING,
+        ],
+    );
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlsize>
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Default)]
@@ -24,6 +35,17 @@ pub struct MTLSize {
     pub width: NSUInteger,
     pub height: NSUInteger,
     pub depth: NSUInteger,
+}
+
+unsafe impl Encode for MTLSize {
+    const ENCODING: Encoding = Encoding::Struct(
+        "?",
+        &[
+            NSUInteger::ENCODING,
+            NSUInteger::ENCODING,
+            NSUInteger::ENCODING,
+        ],
+    );
 }
 
 impl MTLSize {
@@ -42,6 +64,11 @@ impl MTLSize {
 pub struct MTLRegion {
     pub origin: MTLOrigin,
     pub size: MTLSize,
+}
+
+unsafe impl Encode for MTLRegion {
+    const ENCODING: Encoding =
+        Encoding::Struct("MTLRegion", &[MTLOrigin::ENCODING, MTLSize::ENCODING]);
 }
 
 impl MTLRegion {
@@ -83,8 +110,17 @@ pub struct MTLSamplePosition {
     pub y: f32,
 }
 
+unsafe impl Encode for MTLSamplePosition {
+    const ENCODING: Encoding =
+        Encoding::Struct("MTLSamplePosition", &[f32::ENCODING, f32::ENCODING]);
+}
+
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Default)]
 pub struct MTLResourceID {
     pub _impl: u64,
+}
+
+unsafe impl Encode for MTLResourceID {
+    const ENCODING: Encoding = Encoding::Struct("MTLResourceID", &[u64::ENCODING]);
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -68,7 +68,7 @@ pub struct MTLRegion {
 
 unsafe impl Encode for MTLRegion {
     const ENCODING: Encoding =
-        Encoding::Struct("MTLRegion", &[MTLOrigin::ENCODING, MTLSize::ENCODING]);
+        Encoding::Struct("?", &[MTLOrigin::ENCODING, MTLSize::ENCODING]);
 }
 
 impl MTLRegion {
@@ -112,7 +112,7 @@ pub struct MTLSamplePosition {
 
 unsafe impl Encode for MTLSamplePosition {
     const ENCODING: Encoding =
-        Encoding::Struct("MTLSamplePosition", &[f32::ENCODING, f32::ENCODING]);
+        Encoding::Struct("?", &[f32::ENCODING, f32::ENCODING]);
 }
 
 #[repr(C)]

--- a/src/vertexdescriptor.rs
+++ b/src/vertexdescriptor.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use super::NSUInteger;
+use super::*;
 
 /// See <https://developer.apple.com/documentation/metal/mtlvertexformat>
 #[repr(u64)]
@@ -66,6 +66,10 @@ pub enum MTLVertexFormat {
     Half = 53,
 }
 
+unsafe impl Encode for MTLVertexFormat {
+    const ENCODING: Encoding = u64::ENCODING;
+}
+
 /// See <https://developer.apple.com/documentation/metal/mtlvertexstepfunction>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -75,6 +79,10 @@ pub enum MTLVertexStepFunction {
     PerInstance = 2,
     PerPatch = 3,
     PerPatchControlPoint = 4,
+}
+
+unsafe impl Encode for MTLVertexStepFunction {
+    const ENCODING: Encoding = u64::ENCODING;
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlvertexbufferlayoutdescriptor>


### PR DESCRIPTION
Replace `objc` with my fork, [`objc2`](https://github.com/madsmtm/objc2).

This crate contains many improvements, in particular:
- Better tools for protecting against UB (see first commit)
- You no longer have to worry about using `bool` in `msg_send!`.
- The `msg_send_id!` macro greatly helps with follow memory management rules (similar to Objective-C ARC), potentially also alleviating a lot of the need for autoreleasepools.
- The `extern_protocol!` macro is used in place of `foreign_obj_type!`

Notable breaking changes:
- `objc2::Message` differs from `objc::Message`, so message sending is not compatible
- `NSUInteger` is now `usize` instead of `u32`/`u64` depending on platform (equivalently for `NSInteger`)
- There is no longer three types for each class (e.g. `MTLFoo`, `Foo` and `FooRef`); these have been combined into one: `Foo`. Pointers to this can be used across FFI boundaries, and `objc2::rc::Id<Foo, Shared>` can be used as a strong pointer. In table form:

  | Previously | Now |
  | --- | --- |
  | `*mut MTLFoo` | `*mut Foo` |
  | `&FooRef` | `&Foo` |
  | `Foo` | `Id<Foo, Shared>` |

When done, this should resolve the following issues:
- Fixes https://github.com/gfx-rs/metal-rs/issues/5 now
- Later: https://github.com/gfx-rs/metal-rs/issues/222
- Later: https://github.com/gfx-rs/metal-rs/issues/218
- Later: https://github.com/gfx-rs/metal-rs/issues/128
- Later: https://github.com/gfx-rs/metal-rs/issues/86
- Later: https://github.com/gfx-rs/metal-rs/issues/99
- Later: https://github.com/gfx-rs/metal-rs/issues/225
- Later: https://github.com/gfx-rs/metal-rs/issues/58
- Later: https://github.com/gfx-rs/metal-rs/issues/282
- Later: https://github.com/gfx-rs/metal-rs/issues/284
