### PR TITLE
added convenience, build buffer from slice, leveraging rust generics …

### DIFF
--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -19,17 +19,14 @@ fn main() {
             24, 25, 26, 27, 28, 29, 30,
         ];
 
-        let buffer = device.new_buffer_with_data(
-            unsafe { mem::transmute(data.as_ptr()) },
-            (data.len() * mem::size_of::<u32>()) as u64,
+        let buffer = device.new_buffer_from_slice(&data[..],
             MTLResourceOptions::CPUCacheModeDefaultCache,
         );
 
         let sum = {
             let data = [0u32];
-            device.new_buffer_with_data(
-                unsafe { mem::transmute(data.as_ptr()) },
-                (data.len() * mem::size_of::<u32>()) as u64,
+            device.new_buffer_from_slice(
+                &data[..],
                 MTLResourceOptions::CPUCacheModeDefaultCache,
             )
         };

--- a/src/device.rs
+++ b/src/device.rs
@@ -1965,6 +1965,18 @@ impl DeviceRef {
                                        options:options]
         }
     }
+    
+    pub fn new_buffer_from_slice<T:Copy>(
+        &self,
+        data:&[T],
+        options:MTLResourceOptions 
+    )-> Buffer {
+        self.new_buffer_with_data(
+            &data[0] as *const _ as *const std::ffi::c_void,
+            (data.len() * std::mem::size_of::<T>()) as NSUInteger,
+            options
+        )
+    }
 
     pub fn new_texture(&self, descriptor: &TextureDescriptorRef) -> Texture {
         unsafe { msg_send![self, newTextureWithDescriptor: descriptor] }


### PR DESCRIPTION
.. I realise the intent is probably to give an API that is a 1:1 translation of the objC/swift originals, but I'm guessing almost everyone is going to write this buffer constructor helper, and this kind of streamlining makes the example easier to comprehend.

any thoughts?