### PR TITLE
Link to Apple Documentation, explain docs.rs failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 [![Actions Status](https://github.com/gfx-rs/metal-rs/workflows/ci/badge.svg)](https://github.com/gfx-rs/metal-rs/actions)
 [![Crates.io](https://img.shields.io/crates/v/metal.svg?label=metal)](https://crates.io/crates/metal)
 
-Unsafe Rust bindings for the Metal 3D Graphics API.
+<p align="center">
+  <img width="150" height="150" src="./assets/metal.svg">
+</p>
+
+<p align="center">Unsafe Rust bindings for the Metal 3D Graphics API.</p>
+
+## Documentation
+
+Note that [docs.rs](docs.rs) will fail to build the (albiet limited) documentation for this crate!
+They build in a Linux container, but of course this will only compile on MacOS.
+
+Please build the documentation yourself with `cargo docs`.
 
 ## Examples
 

--- a/assets/metal.svg
+++ b/assets/metal.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="720px" height="720px" viewBox="0 0 720 720" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="limeGradient">
+            <stop stop-color="#0EFFDD" offset="0%"></stop>
+            <stop stop-color="#24FF74" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g>
+        <g>
+            <path d="M576,720 L144,720 C64.5,720 0,655.5 0,576 L0,144 C0,64.5 64.5,0 144,0 L576,0 C655.5,0 720,64.5 720,144 L720,576 C720,655.5 655.5,720 576,720 Z" id="app-backplate" fill="url(#limeGradient)"></path>
+            <polygon id="Path" fill="#000000" points="141 132 334 368 334 195 651 545 569 545 398 364 396 545 205 309 205 545 141 545"></polygon>
+        </g>
+    </g>
+</svg>

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -8,6 +8,7 @@
 use super::{MTLTextureType, NSUInteger};
 use objc::runtime::{NO, YES};
 
+/// See <https://developer.apple.com/documentation/metal/mtldatatype>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -107,7 +108,9 @@ pub enum MTLDataType {
     RGB9E5Float = 77,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlargumenttype>
 #[repr(u64)]
+#[deprecated(note = "Since: iOS 8.0–16.0, iPadOS 8.0–16.0, macOS 10.11–13.0, Mac Catalyst 13.1–16.0, tvOS 9.0–16.0")]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLArgumentType {
@@ -119,6 +122,7 @@ pub enum MTLArgumentType {
     Imageblock = 17,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlargumentaccess>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -128,6 +132,7 @@ pub enum MTLArgumentAccess {
     WriteOnly = 2,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlstructmember>
 pub enum MTLStructMember {}
 
 foreign_obj_type! {
@@ -179,6 +184,7 @@ impl StructMemberArrayRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlstructtype>
 pub enum MTLStructType {}
 
 foreign_obj_type! {
@@ -199,6 +205,7 @@ impl StructTypeRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlarraytype>
 pub enum MTLArrayType {}
 
 foreign_obj_type! {
@@ -229,6 +236,8 @@ impl ArrayTypeRef {
     }
 }
 
+/// <https://developer.apple.com/documentation/metal/mtlargument>
+#[deprecated(note = "Since iOS 8.0–16.0, iPadOS 8.0–16.0, macOS 10.11–13.0, Mac Catalyst 13.1–16.0, tvOS 9.0–16.0")]
 pub enum MTLArgument {}
 
 foreign_obj_type! {
@@ -300,6 +309,7 @@ impl ArgumentRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlargumentdescriptor>
 pub enum MTLArgumentDescriptor {}
 
 foreign_obj_type! {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -7,6 +7,7 @@
 
 use super::*;
 
+/// See <https://developer.apple.com/documentation/metal/mtlbuffer>
 pub enum MTLBuffer {}
 
 foreign_obj_type! {

--- a/src/capturedescriptor.rs
+++ b/src/capturedescriptor.rs
@@ -9,7 +9,7 @@ use super::*;
 
 use std::path::Path;
 
-/// https://developer.apple.com/documentation/metal/mtlcapturedestination?language=objc
+/// See <https://developer.apple.com/documentation/metal/mtlcapturedestination?language=objc>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -18,7 +18,7 @@ pub enum MTLCaptureDestination {
     GpuTraceDocument = 2,
 }
 
-/// https://developer.apple.com/documentation/metal/mtlcapturedescriptor
+/// See <https://developer.apple.com/documentation/metal/mtlcapturedescriptor>
 pub enum MTLCaptureDescriptor {}
 
 foreign_obj_type! {
@@ -37,22 +37,22 @@ impl CaptureDescriptor {
 }
 
 impl CaptureDescriptorRef {
-    /// https://developer.apple.com/documentation/metal/mtlcapturedescriptor/3237248-captureobject
+    /// See <https://developer.apple.com/documentation/metal/mtlcapturedescriptor/3237248-captureobject>
     pub fn set_capture_device(&self, device: &DeviceRef) {
         unsafe { msg_send![self, setCaptureObject: device] }
     }
 
-    /// https://developer.apple.com/documentation/metal/mtlcapturedescriptor/3237248-captureobject
+    /// See <https://developer.apple.com/documentation/metal/mtlcapturedescriptor/3237248-captureobject>
     pub fn set_capture_scope(&self, scope: &CaptureScopeRef) {
         unsafe { msg_send![self, setCaptureObject: scope] }
     }
 
-    /// https://developer.apple.com/documentation/metal/mtlcapturedescriptor/3237248-captureobject
+    /// See <https://developer.apple.com/documentation/metal/mtlcapturedescriptor/3237248-captureobject>
     pub fn set_capture_command_queue(&self, command_queue: &CommandQueueRef) {
         unsafe { msg_send![self, setCaptureObject: command_queue] }
     }
 
-    /// https://developer.apple.com/documentation/metal/mtlcapturedescriptor/3237250-outputurl
+    /// See <https://developer.apple.com/documentation/metal/mtlcapturedescriptor/3237250-outputurl>
     pub fn output_url(&self) -> &Path {
         let output_url = unsafe { msg_send![self, outputURL] };
         let output_url = nsstring_as_str(output_url);
@@ -60,19 +60,19 @@ impl CaptureDescriptorRef {
         Path::new(output_url)
     }
 
-    /// https://developer.apple.com/documentation/metal/mtlcapturedescriptor/3237250-outputurl
+    /// See <https://developer.apple.com/documentation/metal/mtlcapturedescriptor/3237250-outputurl>
     pub fn set_output_url<P: AsRef<Path>>(&self, output_url: P) {
         let output_url = nsstring_from_str(output_url.as_ref().to_str().unwrap());
 
         unsafe { msg_send![self, setOutputURL: output_url] }
     }
 
-    /// https://developer.apple.com/documentation/metal/mtlcapturedescriptor?language=objc
+    /// See <https://developer.apple.com/documentation/metal/mtlcapturedescriptor?language=objc>
     pub fn destination(&self) -> MTLCaptureDestination {
         unsafe { msg_send![self, destination] }
     }
 
-    /// https://developer.apple.com/documentation/metal/mtlcapturedescriptor?language=objc
+    /// See <https://developer.apple.com/documentation/metal/mtlcapturedescriptor?language=objc>
     pub fn set_destination(&self, destination: MTLCaptureDestination) {
         unsafe { msg_send![self, setDestination: destination] }
     }

--- a/src/capturemanager.rs
+++ b/src/capturemanager.rs
@@ -8,6 +8,7 @@
 use super::*;
 use std::ffi::CStr;
 
+/// See <https://developer.apple.com/documentation/metal/mtlcapturescope>
 pub enum MTLCaptureScope {}
 
 foreign_obj_type! {
@@ -33,6 +34,7 @@ impl CaptureScopeRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlcapturemanager>
 pub enum MTLCaptureManager {}
 
 foreign_obj_type! {
@@ -70,7 +72,7 @@ impl CaptureManagerRef {
         unsafe { msg_send![self, setDefaultCaptureScope: scope] }
     }
 
-    /// https://developer.apple.com/documentation/metal/mtlcapturemanager/3237259-startcapture
+    /// See <https://developer.apple.com/documentation/metal/mtlcapturemanager/3237259-startcapture>
     pub fn start_capture(&self, descriptor: &CaptureDescriptorRef) -> Result<(), String> {
         unsafe {
             try_objc! { err =>
@@ -100,7 +102,7 @@ impl CaptureManagerRef {
         unsafe { msg_send![self, isCapturing] }
     }
 
-    /// https://developer.apple.com/documentation/metal/mtlcapturemanager/3237260-supportsdestination?language=objc
+    /// See <https://developer.apple.com/documentation/metal/mtlcapturemanager/3237260-supportsdestination?language=objc>
     pub fn supports_destination(&self, destination: MTLCaptureDestination) -> bool {
         unsafe { msg_send![self, supportsDestination: destination] }
     }

--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -9,6 +9,7 @@ use super::*;
 
 use block::Block;
 
+/// See <https://developer.apple.com/documentation/metal/mtlcommandbufferstatus>
 #[repr(u32)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -21,6 +22,7 @@ pub enum MTLCommandBufferStatus {
     Error = 5,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlcommandbuffererror>
 #[repr(u32)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -37,6 +39,7 @@ pub enum MTLCommandBufferError {
     DeviceRemoved = 11,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtldispatchtype>
 #[repr(u32)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -47,6 +50,7 @@ pub enum MTLDispatchType {
 
 type CommandBufferHandler<'a> = Block<(&'a CommandBufferRef,), ()>;
 
+/// See <https://developer.apple.com/documentation/metal/mtlcommandbuffer>.
 pub enum MTLCommandBuffer {}
 
 foreign_obj_type! {

--- a/src/commandqueue.rs
+++ b/src/commandqueue.rs
@@ -7,6 +7,7 @@
 
 use super::*;
 
+/// See <https://developer.apple.com/documentation/metal/mtlcommandqueue>.
 pub enum MTLCommandQueue {}
 
 foreign_obj_type! {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+/// See <https://developer.apple.com/documentation/metal/mtlpixelformat>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/src/depthstencil.rs
+++ b/src/depthstencil.rs
@@ -8,6 +8,7 @@
 use crate::DeviceRef;
 use objc::runtime::{NO, YES};
 
+/// See <https://developer.apple.com/documentation/metal/mtlcomparefunction>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLCompareFunction {
@@ -21,6 +22,7 @@ pub enum MTLCompareFunction {
     Always = 7,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlstenciloperation>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLStencilOperation {
@@ -34,6 +36,7 @@ pub enum MTLStencilOperation {
     DecrementWrap = 7,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlstencildescriptor>
 pub enum MTLStencilDescriptor {}
 
 foreign_obj_type! {
@@ -101,6 +104,7 @@ impl StencilDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtldepthstencildescriptor>
 pub enum MTLDepthStencilDescriptor {}
 
 foreign_obj_type! {
@@ -172,6 +176,7 @@ impl DepthStencilDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtldepthstencilstate>
 pub enum MTLDepthStencilState {}
 
 foreign_obj_type! {

--- a/src/device.rs
+++ b/src/device.rs
@@ -13,8 +13,11 @@ use objc::runtime::{Object, NO, YES};
 
 use std::{ffi::CStr, os::raw::c_char, path::Path, ptr};
 
-// Available on macOS 10.11+, iOS 8.0+, tvOS 9.0+
+/// Available on macOS 10.11+, iOS 8.0+, tvOS 9.0+
+///
+/// See <https://developer.apple.com/documentation/metal/mtlfeatureset>
 #[allow(non_camel_case_types)]
+#[deprecated(note = "Since iOS 8.0–16.0 iPadOS 8.0–16.0 macOS 10.11–13.0 Mac Catalyst 13.1–16.0 tvOS 9.0–16.0")]
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLFeatureSet {
@@ -52,7 +55,9 @@ pub enum MTLFeatureSet {
     macOS_GPUFamily2_v1 = 10005,
 }
 
-// Available on macOS 10.15+, iOS 13.0+
+/// Available on macOS 10.15+, iOS 13.0+
+///
+/// See <https://developer.apple.com/documentation/metal/mtlgpufamily>
 #[repr(i64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[non_exhaustive]
@@ -75,6 +80,7 @@ pub enum MTLGPUFamily {
     MacCatalyst2 = 4002,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtldevicelocation>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLDeviceLocation {
@@ -1380,6 +1386,7 @@ impl MTLFeatureSet {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlargumentbufferstier>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLArgumentBuffersTier {
@@ -1387,6 +1394,7 @@ pub enum MTLArgumentBuffersTier {
     Tier2 = 1,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlreadwritetexturetier>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLReadWriteTextureTier {
@@ -1396,6 +1404,8 @@ pub enum MTLReadWriteTextureTier {
 }
 
 /// Only available on (macos(11.0), ios(14.0))
+///
+/// See <https://developer.apple.com/documentation/metal/mtlcountersamplingpoint>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLCounterSamplingPoint {
@@ -1407,6 +1417,9 @@ pub enum MTLCounterSamplingPoint {
 }
 
 /// Only available on (macos(11.0), macCatalyst(14.0), ios(13.0))
+/// Kinda a long name!
+///
+/// See <https://developer.apple.com/documentation/metal/mtlsparsetextureregionalignmentmode>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLSparseTextureRegionAlignmentMode {
@@ -1431,6 +1444,7 @@ bitflags! {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlaccelerationstructuresizes>
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[repr(C)]
 pub struct MTLAccelerationStructureSizes {
@@ -1480,6 +1494,7 @@ type MTLNewRenderPipelineStateWithReflectionCompletionHandler = extern fn(render
 type MTLNewComputePipelineStateCompletionHandler = extern fn(computePipelineState: id, error: id);
 type MTLNewComputePipelineStateWithReflectionCompletionHandler = extern fn(computePipelineState: id, reflection: id, error: id);*/
 
+/// See <https://developer.apple.com/documentation/metal/mtldevice>
 pub enum MTLDevice {}
 
 foreign_obj_type! {

--- a/src/drawable.rs
+++ b/src/drawable.rs
@@ -7,6 +7,7 @@
 
 use super::NSUInteger;
 
+/// See <https://developer.apple.com/documentation/metal/mtldrawable>
 pub enum MTLDrawable {}
 
 foreign_obj_type! {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -9,6 +9,7 @@ use super::*;
 
 use std::ops::Range;
 
+/// See <https://developer.apple.com/documentation/metal/mtlprimitivetype>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLPrimitiveType {
@@ -19,6 +20,7 @@ pub enum MTLPrimitiveType {
     TriangleStrip = 4,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlindextype>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -27,6 +29,7 @@ pub enum MTLIndexType {
     UInt32 = 1,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlvisibilityresultmode>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLVisibilityResultMode {
@@ -35,6 +38,7 @@ pub enum MTLVisibilityResultMode {
     Counting = 2,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlcullmode>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLCullMode {
@@ -43,6 +47,7 @@ pub enum MTLCullMode {
     Back = 2,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlwinding>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLWinding {
@@ -50,6 +55,7 @@ pub enum MTLWinding {
     CounterClockwise = 1,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtldepthclipmode>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLDepthClipMode {
@@ -57,6 +63,7 @@ pub enum MTLDepthClipMode {
     Clamp = 1,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtltrianglefillmode>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLTriangleFillMode {
@@ -79,6 +86,7 @@ bitflags! {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlscissorrect>
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct MTLScissorRect {
@@ -88,6 +96,7 @@ pub struct MTLScissorRect {
     pub height: NSUInteger,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlviewport>
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct MTLViewport {
@@ -99,6 +108,7 @@ pub struct MTLViewport {
     pub zfar: f64,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtldrawprimitivesindirectarguments>
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct MTLDrawPrimitivesIndirectArguments {
@@ -108,6 +118,7 @@ pub struct MTLDrawPrimitivesIndirectArguments {
     pub baseInstance: u32,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtldrawindexedprimitivesindirectarguments>
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct MTLDrawIndexedPrimitivesIndirectArguments {
@@ -118,6 +129,7 @@ pub struct MTLDrawIndexedPrimitivesIndirectArguments {
     pub baseInstance: u32,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlvertexamplificationviewmapping>
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct VertexAmplificationViewMapping {
@@ -125,6 +137,10 @@ pub struct VertexAmplificationViewMapping {
     pub viewportArrayIndexOffset: u32,
 }
 
+#[allow(dead_code)]
+type MTLVertexAmplicationViewMapping = VertexAmplificationViewMapping;
+
+/// See <https://developer.apple.com/documentation/metal/mtlcommandencoder>
 pub enum MTLCommandEncoder {}
 
 foreign_obj_type! {
@@ -171,6 +187,7 @@ impl CommandEncoderRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlparallelrendercommandencoder>
 pub enum MTLParallelRenderCommandEncoder {}
 
 foreign_obj_type! {
@@ -186,6 +203,7 @@ impl ParallelRenderCommandEncoderRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlrendercommandencoder/>
 pub enum MTLRenderCommandEncoder {}
 
 foreign_obj_type! {
@@ -819,6 +837,7 @@ impl RenderCommandEncoderRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlblitcommandencoder/>
 pub enum MTLBlitCommandEncoder {}
 
 foreign_obj_type! {
@@ -922,7 +941,7 @@ impl BlitCommandEncoderRef {
         }
     }
 
-    /// https://developer.apple.com/documentation/metal/mtlblitcommandencoder/1400756-copy
+    /// See <https://developer.apple.com/documentation/metal/mtlblitcommandencoder/1400756-copy>
     pub fn copy_from_texture_to_buffer(
         &self,
         source_texture: &TextureRef,
@@ -999,6 +1018,7 @@ impl BlitCommandEncoderRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlcomputecommandencoder/>
 pub enum MTLComputeCommandEncoder {}
 
 foreign_obj_type! {
@@ -1238,6 +1258,7 @@ impl ComputeCommandEncoderRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlargumentencoder/>
 pub enum MTLArgumentEncoder {}
 
 foreign_obj_type! {

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -8,6 +8,8 @@
 use super::*;
 
 /// Only available on macos(10.15), ios(13.0)
+///
+/// See <https://developer.apple.com/documentation/metal/mtlheaptype/>
 #[repr(u64)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLHeapType {
@@ -17,6 +19,7 @@ pub enum MTLHeapType {
     Sparse = 2,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlheap/>
 pub enum MTLHeap {}
 
 foreign_obj_type! {
@@ -148,6 +151,7 @@ impl HeapRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlheapdescriptor/>
 pub enum MTLHeapDescriptor {}
 
 foreign_obj_type! {

--- a/src/indirect_encoder.rs
+++ b/src/indirect_encoder.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 bitflags! {
+    /// See <https://developer.apple.com/documentation/metal/mtlindirectcommandtype/>
     #[allow(non_upper_case_globals)]
     pub struct MTLIndirectCommandType: NSUInteger {
         const Draw                      = 1 << 0;
@@ -12,6 +13,7 @@ bitflags! {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlindirectcommandbufferdescriptor/>
 pub enum MTLIndirectCommandBufferDescriptor {}
 
 foreign_obj_type! {
@@ -82,6 +84,7 @@ impl IndirectCommandBufferDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlindirectcommandbuffer/>
 pub enum MTLIndirectCommandBuffer {}
 
 foreign_obj_type! {
@@ -112,6 +115,7 @@ impl IndirectCommandBufferRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlindirectrendercommand/>
 pub enum MTLIndirectRenderCommand {}
 
 foreign_obj_type! {
@@ -266,6 +270,7 @@ impl IndirectRenderCommandRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlindirectcomputecommand/>
 pub enum MTLIndirectComputeCommand {}
 
 foreign_obj_type! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+#![allow(deprecated)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 
@@ -29,15 +30,23 @@ use core_graphics_types::{base::CGFloat, geometry::CGSize};
 use foreign_types::ForeignType;
 use objc::runtime::{Object, NO, YES};
 
+/// See <https://developer.apple.com/documentation/objectivec/nsinteger>
 #[cfg(target_pointer_width = "64")]
 pub type NSInteger = i64;
+
+/// See <https://developer.apple.com/documentation/objectivec/nsinteger>
 #[cfg(not(target_pointer_width = "64"))]
 pub type NSInteger = i32;
+
+/// See <https://developer.apple.com/documentation/objectivec/nsuinteger>
 #[cfg(target_pointer_width = "64")]
 pub type NSUInteger = u64;
+
+/// See <https://developer.apple.com/documentation/objectivec/nsuinteger>
 #[cfg(target_pointer_width = "32")]
 pub type NSUInteger = u32;
 
+/// See <https://developer.apple.com/documentation/foundation/nsrange>
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct NSRange {
@@ -156,6 +165,7 @@ macro_rules! try_objc {
     };
 }
 
+/// See <https://developer.apple.com/documentation/foundation/nsarray>
 pub struct NSArray<T> {
     _phantom: PhantomData<T>,
 }
@@ -284,6 +294,7 @@ where
     }
 }
 
+/// See <https://developer.apple.com/documentation/quartzcore/cametaldrawable>
 pub enum CAMetalDrawable {}
 
 foreign_obj_type! {
@@ -299,6 +310,7 @@ impl MetalDrawableRef {
     }
 }
 
+// See <https://developer.apple.com/documentation/quartzcore/cametallayer>
 pub enum CAMetalLayer {}
 
 foreign_obj_type! {
@@ -521,6 +533,7 @@ unsafe fn obj_clone<T: 'static>(p: *mut T) -> *mut T {
 type c_size_t = usize;
 
 // TODO: expand supported interface
+/// See <https://developer.apple.com/documentation/foundation/nsurl>
 pub enum NSURL {}
 
 foreign_obj_type! {

--- a/src/library.rs
+++ b/src/library.rs
@@ -15,6 +15,8 @@ use std::os::raw::{c_char, c_void};
 use std::ptr;
 
 /// Only available on (macos(10.12), ios(10.0)
+///
+/// See <https://developer.apple.com/documentation/metal/mtlpatchtype/>
 #[repr(u64)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLPatchType {
@@ -23,6 +25,7 @@ pub enum MTLPatchType {
     Quad = 2,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlvertexattribute/>
 pub enum MTLVertexAttribute {}
 
 foreign_obj_type! {
@@ -81,6 +84,8 @@ impl VertexAttributeRef {
 }
 
 /// Only available on (macos(10.12), ios(10.0))
+///
+/// See <https://developer.apple.com/documentation/metal/mtlattribute/>
 pub enum MTLAttribute {}
 
 foreign_obj_type! {
@@ -138,6 +143,7 @@ impl AttributeRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlfunctiontype/>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLFunctionType {
@@ -151,6 +157,8 @@ pub enum MTLFunctionType {
 }
 
 /// Only available on (macos(10.12), ios(10.0))
+///
+/// See <https://developer.apple.com/documentation/metal/mtlfunctionconstant/>
 pub enum MTLFunctionConstant {}
 
 foreign_obj_type! {
@@ -188,6 +196,8 @@ impl FunctionConstantRef {
 
 bitflags! {
     /// Only available on (macos(11.0), ios(14.0))
+    ///
+    /// See <https://developer.apple.com/documentation/metal/mtlfunctionoptions/>
     pub struct MTLFunctionOptions: NSUInteger {
         const None = 0;
         const CompileToBinary = 1 << 0;
@@ -195,6 +205,8 @@ bitflags! {
 }
 
 /// Only available on (macos(11.0), ios(14.0))
+///
+/// See <https://developer.apple.com/documentation/metal/mtlfunctiondescriptor/>
 pub enum MTLFunctionDescriptor {}
 
 foreign_obj_type! {
@@ -259,6 +271,8 @@ impl FunctionDescriptorRef {
 }
 
 /// Only available on (macos(11.0), ios(14.0))
+///
+/// See <https://developer.apple.com/documentation/metal/mtlintersectionfunctiondescriptor/>
 pub enum MTLIntersectionFunctionDescriptor {}
 
 foreign_obj_type! {
@@ -269,6 +283,8 @@ foreign_obj_type! {
 }
 
 /// Only available on (macos(11.0), ios(14.0))
+///
+/// See <https://developer.apple.com/documentation/metal/mtlfunctionhandle/>
 pub enum MTLFunctionHandle {}
 
 foreign_obj_type! {
@@ -301,6 +317,7 @@ impl FunctionHandleRef {
 // MTLIntersectionFunctionTableDescriptor
 // MTLIntersectionFunctionTable
 
+/// See <https://developer.apple.com/documentation/metal/mtlfunction/>
 pub enum MTLFunction {}
 
 foreign_obj_type! {
@@ -378,6 +395,7 @@ impl FunctionRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtllanguageversion/>
 #[repr(u64)]
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub enum MTLLanguageVersion {
@@ -393,6 +411,7 @@ pub enum MTLLanguageVersion {
     V2_4 = 0x20004,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlfunctionconstantvalues/>
 pub enum MTLFunctionConstantValues {}
 
 foreign_obj_type! {
@@ -438,6 +457,8 @@ impl FunctionConstantValuesRef {
 }
 
 /// Only available on (macos(11.0), ios(14.0))
+///
+/// See <https://developer.apple.com/documentation/metal/mtllibrarytype/>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLLibraryType {
@@ -445,6 +466,7 @@ pub enum MTLLibraryType {
     Dynamic = 1,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlcompileoptions/>
 pub enum MTLCompileOptions {}
 
 foreign_obj_type! {
@@ -577,6 +599,7 @@ impl CompileOptionsRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtllibraryerror/>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLLibraryError {
@@ -590,6 +613,7 @@ pub enum MTLLibraryError {
     FileNotFound = 6,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtllibrary/>
 pub enum MTLLibrary {}
 
 foreign_obj_type! {
@@ -719,6 +743,8 @@ impl LibraryRef {
 }
 
 /// Only available on (macos(11.0), ios(14.0))
+///
+/// See <https://developer.apple.com/documentation/metal/mtldynamiclibraryerror/>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLDynamicLibraryError {
@@ -730,6 +756,7 @@ pub enum MTLDynamicLibraryError {
     Unsupported = 5,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtldynamiclibrary/>
 pub enum MTLDynamicLibrary {}
 
 foreign_obj_type! {
@@ -787,6 +814,8 @@ impl DynamicLibraryRef {
 }
 
 /// macOS 11.0+ iOS 14.0+
+///
+/// See <https://developer.apple.com/documentation/metal/mtlbinaryarchivedescriptor/>
 pub enum MTLBinaryArchiveDescriptor {}
 
 foreign_obj_type! {
@@ -814,6 +843,8 @@ impl BinaryArchiveDescriptorRef {
 }
 
 /// macOS 11.0+ iOS 14.0+
+///
+/// See <https://developer.apple.com/documentation/metal/mtlbinaryarchive/>
 pub enum MTLBinaryArchive {}
 
 foreign_obj_type! {
@@ -916,6 +947,8 @@ impl BinaryArchiveRef {
 }
 
 /// macOS 11.0+ iOS 14.0+
+///
+/// See <https://developer.apple.com/documentation/metal/mtllinkedfunctions/>
 pub enum MTLLinkedFunctions {}
 
 foreign_obj_type! {

--- a/src/mps.rs
+++ b/src/mps.rs
@@ -22,6 +22,7 @@ pub fn mps_supports_device(device: &DeviceRef) -> bool {
     b == YES
 }
 
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpskernel>
 pub enum MPSKernel {}
 
 foreign_obj_type! {
@@ -30,6 +31,7 @@ foreign_obj_type! {
     pub struct KernelRef;
 }
 
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsraydatatype>
 pub enum MPSRayDataType {
     OriginDirection = 0,
     OriginMinDistanceDirectionMaxDistance = 1,
@@ -37,6 +39,7 @@ pub enum MPSRayDataType {
 }
 
 bitflags! {
+    /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsraymaskoptions>
     #[allow(non_upper_case_globals)]
     pub struct MPSRayMaskOptions: NSUInteger {
         /// Enable primitive masks
@@ -47,6 +50,8 @@ bitflags! {
 }
 
 /// Options that determine the data contained in an intersection result.
+///
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsintersectiondatatype>
 pub enum MPSIntersectionDataType {
     Distance = 0,
     DistancePrimitiveIndex = 1,
@@ -55,6 +60,7 @@ pub enum MPSIntersectionDataType {
     DistancePrimitiveIndexInstanceIndexCoordinates = 4,
 }
 
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsintersectiontype>
 pub enum MPSIntersectionType {
     /// Find the closest intersection to the ray's origin along the ray direction.
     /// This is potentially slower than `Any` but is well suited to primary visibility rays.
@@ -64,6 +70,7 @@ pub enum MPSIntersectionType {
     Any = 1,
 }
 
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsraymaskoperator>
 pub enum MPSRayMaskOperator {
     /// Accept the intersection if `(primitive mask & ray mask) != 0`.
     And = 0,
@@ -89,6 +96,7 @@ pub enum MPSRayMaskOperator {
     GreaterThanOrEqualTo = 9,
 }
 
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpstriangleintersectiontesttype>
 pub enum MPSTriangleIntersectionTestType {
     /// Use the default ray/triangle intersection test
     Default = 0,
@@ -98,6 +106,7 @@ pub enum MPSTriangleIntersectionTestType {
     Watertight = 1,
 }
 
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsaccelerationstructurestatus>
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MPSAccelerationStructureStatus {
     Unbuilt = 0,
@@ -105,6 +114,7 @@ pub enum MPSAccelerationStructureStatus {
 }
 
 bitflags! {
+    /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsaccelerationstructureusage>
     #[allow(non_upper_case_globals)]
     pub struct MPSAccelerationStructureUsage: NSUInteger {
         /// No usage options specified
@@ -123,6 +133,7 @@ const MPSDataTypeFloatBit: isize = 0x10000000;
 const MPSDataTypeSignedBit: isize = 0x20000000;
 const MPSDataTypeNormalizedBit: isize = 0x40000000;
 
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsdatatype>
 pub enum MPSDataType {
     Invalid = 0,
 
@@ -145,6 +156,8 @@ pub enum MPSDataType {
 }
 
 /// A kernel that performs intersection tests between rays and geometry.
+///
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsrayintersector>
 pub enum MPSRayIntersector {}
 
 foreign_obj_type! {
@@ -247,7 +260,9 @@ impl RayIntersectorRef {
     }
 }
 
-/// A group of acceleration structures which may be used together in an instance acceleration structure
+/// A group of acceleration structures which may be used together in an instance acceleration structure.
+///
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsaccelerationstructuregroup>
 pub enum MPSAccelerationStructureGroup {}
 
 foreign_obj_type! {
@@ -278,6 +293,8 @@ impl AccelerationStructureGroupRef {
 }
 
 /// The base class for data structures that are built over geometry and used to accelerate ray tracing.
+///
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsaccelerationstructure>
 pub enum MPSAccelerationStructure {}
 
 foreign_obj_type! {
@@ -312,6 +329,7 @@ impl AccelerationStructureRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpspolygonaccelerationstructure>
 pub enum MPSPolygonAccelerationStructure {}
 
 foreign_obj_type! {
@@ -356,6 +374,8 @@ impl PolygonAccelerationStructureRef {
 }
 
 /// An acceleration structure built over triangles.
+///
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpstriangleaccelerationstructure>
 pub enum MPSTriangleAccelerationStructure {}
 
 foreign_obj_type! {
@@ -390,6 +410,7 @@ impl TriangleAccelerationStructureRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpstransformtype>
 #[repr(u64)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MPSTransformType {
@@ -398,6 +419,8 @@ pub enum MPSTransformType {
 }
 
 /// An acceleration structure built over instances of other acceleration structures
+///
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsinstanceaccelerationstructure>
 pub enum MPSInstanceAccelerationStructure {}
 
 foreign_obj_type! {
@@ -515,6 +538,8 @@ pub struct MPSPackedFloat3 {
 }
 
 /// Represents a 3D ray with an origin, a direction, and an intersection distance range from the origin.
+///
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsrayoriginmindistancedirectionmaxdistance>
 #[repr(C)]
 pub struct MPSRayOriginMinDistanceDirectionMaxDistance {
     /// Ray origin. The intersection test will be skipped if the origin contains NaNs or infinities.
@@ -533,6 +558,8 @@ pub struct MPSRayOriginMinDistanceDirectionMaxDistance {
 
 /// Intersection result which contains the distance from the ray origin to the intersection point,
 /// the index of the intersected primitive, and the first two barycentric coordinates of the intersection point.
+///
+/// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsintersectiondistanceprimitiveindexcoordinates>
 #[repr(C)]
 pub struct MPSIntersectionDistancePrimitiveIndexCoordinates {
     /// Distance from the ray origin to the intersection point along the ray direction vector such

--- a/src/pipeline/compute.rs
+++ b/src/pipeline/compute.rs
@@ -9,6 +9,7 @@ use super::*;
 
 use objc::runtime::{NO, YES};
 
+/// See <https://developer.apple.com/documentation/metal/mtlattributeformat>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -67,6 +68,7 @@ pub enum MTLAttributeFormat {
     Half = 53,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlstepfunction>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -82,6 +84,7 @@ pub enum MTLStepFunction {
     ThreadPositionInGridYIndexed = 8,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlcomputepipelinedescriptor>
 pub enum MTLComputePipelineDescriptor {}
 
 foreign_obj_type! {
@@ -268,6 +271,7 @@ impl ComputePipelineDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlcomputepipelinestate>
 pub enum MTLComputePipelineState {}
 
 foreign_obj_type! {
@@ -332,6 +336,7 @@ impl ComputePipelineStateRef {
     // - (nullable id <MTLIntersectionFunctionTable>)newIntersectionFunctionTableWithDescriptor:(MTLIntersectionFunctionTableDescriptor * _Nonnull)descriptor
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlstageinputoutputdescriptor>
 pub enum MTLStageInputOutputDescriptor {}
 
 foreign_obj_type! {
@@ -379,6 +384,7 @@ impl StageInputOutputDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlattributedescriptorarray>
 pub enum MTLAttributeDescriptorArray {}
 
 foreign_obj_type! {
@@ -397,6 +403,7 @@ impl AttributeDescriptorArrayRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlattributedescriptor>
 pub enum MTLAttributeDescriptor {}
 
 foreign_obj_type! {
@@ -431,6 +438,7 @@ impl AttributeDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlbufferlayoutdescriptorarray>
 pub enum MTLBufferLayoutDescriptorArray {}
 
 foreign_obj_type! {
@@ -453,6 +461,7 @@ impl BufferLayoutDescriptorArrayRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlbufferlayoutdescriptor>
 pub enum MTLBufferLayoutDescriptor {}
 
 foreign_obj_type! {

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -13,6 +13,7 @@ mod render;
 pub use self::compute::*;
 pub use self::render::*;
 
+/// See <https://developer.apple.com/documentation/metal/mtlmutability>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -29,6 +30,7 @@ impl Default for MTLMutability {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlpipelinebufferdescriptorarray>
 pub enum MTLPipelineBufferDescriptorArray {}
 
 foreign_obj_type! {
@@ -51,6 +53,7 @@ impl PipelineBufferDescriptorArrayRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlpipelinebufferdescriptor>
 pub enum MTLPipelineBufferDescriptor {}
 
 foreign_obj_type! {

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -9,6 +9,7 @@ use super::*;
 
 use objc::runtime::{NO, YES};
 
+/// See <https://developer.apple.com/documentation/metal/mtlblendfactor>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -34,6 +35,7 @@ pub enum MTLBlendFactor {
     OneMinusSource1Alpha = 18,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlblendoperation>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -46,6 +48,7 @@ pub enum MTLBlendOperation {
 }
 
 bitflags! {
+    /// See <https://developer.apple.com/documentation/metal/mtlcolorwritemask>
     pub struct MTLColorWriteMask: NSUInteger {
         const None  = 0;
         const Red   = 0x1 << 3;
@@ -56,6 +59,7 @@ bitflags! {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlprimitivetopologyclass>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -71,6 +75,7 @@ pub enum MTLPrimitiveTopologyClass {
 // TODO: MTLTessellationFactorFormat
 // TODO: MTLTessellationControlPointIndexType
 
+/// See <https://developer.apple.com/documentation/metal/mtlrenderpipelinecolorattachmentdescriptor>
 pub enum MTLRenderPipelineColorAttachmentDescriptor {}
 
 foreign_obj_type! {
@@ -159,6 +164,7 @@ impl RenderPipelineColorAttachmentDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlrenderpipelinereflection>
 pub enum MTLRenderPipelineReflection {}
 
 foreign_obj_type! {
@@ -209,6 +215,7 @@ impl RenderPipelineReflectionRef {
     }
 }
 
+/// TODO: Find documentation link.
 pub enum MTLArgumentArray {}
 
 foreign_obj_type! {
@@ -227,6 +234,7 @@ impl ArgumentArrayRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlcomputepipelinereflection>
 pub enum MTLComputePipelineReflection {}
 
 foreign_obj_type! {
@@ -242,6 +250,7 @@ impl ComputePipelineReflectionRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlrenderpipelinedescriptor>
 pub enum MTLRenderPipelineDescriptor {}
 
 foreign_obj_type! {
@@ -460,6 +469,7 @@ impl RenderPipelineDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlrenderpipelinestate>
 pub enum MTLRenderPipelineState {}
 
 foreign_obj_type! {
@@ -481,6 +491,7 @@ impl RenderPipelineStateRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlrenderpipelinecolorattachmentdescriptorarray>
 pub enum MTLRenderPipelineColorAttachmentDescriptorArray {}
 
 foreign_obj_type! {

--- a/src/renderpass.rs
+++ b/src/renderpass.rs
@@ -7,6 +7,7 @@
 
 use super::*;
 
+/// See <https://developer.apple.com/documentation/metal/mtlloadaction>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug)]
 pub enum MTLLoadAction {
@@ -15,6 +16,7 @@ pub enum MTLLoadAction {
     Clear = 2,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlstoreaction>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug)]
 pub enum MTLStoreAction {
@@ -26,6 +28,7 @@ pub enum MTLStoreAction {
     CustomSampleDepthStore = 5,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlclearcolor>
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct MTLClearColor {
@@ -47,6 +50,7 @@ impl MTLClearColor {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlmultisamplestencilresolvefilter>
 #[repr(u32)]
 #[allow(non_camel_case_types)]
 pub enum MTLMultisampleStencilResolveFilter {
@@ -54,6 +58,7 @@ pub enum MTLMultisampleStencilResolveFilter {
     DepthResolvedSample = 1,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlrenderpassattachmentdescriptor>
 pub enum MTLRenderPassAttachmentDescriptor {}
 
 foreign_obj_type! {
@@ -144,6 +149,7 @@ impl RenderPassAttachmentDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlrenderpasscolorattachmentdescriptor>
 pub enum MTLRenderPassColorAttachmentDescriptor {}
 
 foreign_obj_type! {
@@ -172,6 +178,7 @@ impl RenderPassColorAttachmentDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlrenderpassdepthattachmentdescriptor>
 pub enum MTLRenderPassDepthAttachmentDescriptor {}
 
 foreign_obj_type! {
@@ -191,6 +198,7 @@ impl RenderPassDepthAttachmentDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlrenderpassstencilattachmentdescriptor>
 pub enum MTLRenderPassStencilAttachmentDescriptor {}
 
 foreign_obj_type! {
@@ -221,6 +229,7 @@ impl RenderPassStencilAttachmentDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlrenderpasscolorattachmentdescriptorarray>
 pub enum MTLRenderPassColorAttachmentDescriptorArray {}
 
 foreign_obj_type! {
@@ -246,6 +255,12 @@ impl RenderPassColorAttachmentDescriptorArrayRef {
     }
 }
 
+/// ## Important!
+/// When configuring a [`MTLTextureDescriptor`] object for use with an attachment, set its usage
+/// value to renderTarget if you already know that you intend to use the resulting MTLTexture object in
+/// an attachment. This may significantly improve your app’s performance with certain hardware.
+///
+/// See <https://developer.apple.com/documentation/metal/mtlrenderpassdescriptor>
 pub enum MTLRenderPassDescriptor {}
 
 foreign_obj_type! {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -8,6 +8,7 @@
 use super::{DeviceRef, HeapRef, NSUInteger};
 use objc::runtime::{NO, YES};
 
+/// See <https://developer.apple.com/documentation/metal/mtlpurgeablestate>
 #[repr(u64)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLPurgeableState {
@@ -17,6 +18,7 @@ pub enum MTLPurgeableState {
     Empty = 4,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlcpucachemode>
 #[repr(u64)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLCPUCacheMode {
@@ -24,6 +26,7 @@ pub enum MTLCPUCacheMode {
     WriteCombined = 1,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlstoragemode>
 #[repr(u64)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLStorageMode {
@@ -35,6 +38,8 @@ pub enum MTLStorageMode {
 }
 
 /// Only available on macos(10.15), ios(13.0)
+///
+/// See <https://developer.apple.com/documentation/metal/mtlhazardtrackingmode>
 #[repr(u64)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLHazardTrackingMode {
@@ -51,6 +56,7 @@ pub const MTLResourceHazardTrackingModeShift: NSUInteger = 8;
 pub const MTLResourceHazardTrackingModeMask: NSUInteger = 0x3 << MTLResourceHazardTrackingModeShift;
 
 bitflags! {
+    /// See <https://developer.apple.com/documentation/metal/mtlresourceoptions>
     #[allow(non_upper_case_globals)]
     pub struct MTLResourceOptions: NSUInteger {
         const CPUCacheModeDefaultCache  = (MTLCPUCacheMode::DefaultCache as NSUInteger) << MTLResourceCPUCacheModeShift;
@@ -75,6 +81,8 @@ bitflags! {
     ///
     /// Enabling certain options for certain resources determines whether the Metal driver should
     /// convert the resource to another format (for example, whether to decompress a color render target).
+    ///
+    /// See <https://developer.apple.com/documentation/metal/mtlresourceusage>
     pub struct MTLResourceUsage: NSUInteger {
         /// An option that enables reading from the resource.
         const Read   = 1 << 0;
@@ -87,6 +95,7 @@ bitflags! {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlsizeandalign>
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[repr(C)]
 pub struct MTLSizeAndAlign {
@@ -94,6 +103,7 @@ pub struct MTLSizeAndAlign {
     pub align: NSUInteger,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlresource>
 pub enum MTLResource {}
 
 foreign_obj_type! {

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -7,6 +7,7 @@
 
 use super::{depthstencil::MTLCompareFunction, DeviceRef, NSUInteger};
 
+/// See <https://developer.apple.com/documentation/metal/mtlsamplerminmagfilter>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLSamplerMinMagFilter {
@@ -14,6 +15,7 @@ pub enum MTLSamplerMinMagFilter {
     Linear = 1,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlsamplermipfilter>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLSamplerMipFilter {
@@ -22,6 +24,7 @@ pub enum MTLSamplerMipFilter {
     Linear = 2,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlsampleraddressmode>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLSamplerAddressMode {
@@ -33,6 +36,7 @@ pub enum MTLSamplerAddressMode {
     ClampToBorderColor = 5,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlsamplerbordercolor>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLSamplerBorderColor {
@@ -41,6 +45,7 @@ pub enum MTLSamplerBorderColor {
     OpaqueWhite = 2,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlsamplerdescriptor>
 pub enum MTLSamplerDescriptor {}
 
 foreign_obj_type! {
@@ -135,6 +140,7 @@ impl SamplerDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlsamplerstate>
 pub enum MTLSamplerState {}
 
 foreign_obj_type! {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -12,8 +12,10 @@ use std::mem;
 #[cfg(feature = "dispatch_queue")]
 use dispatch;
 
+/// See <https://developer.apple.com/documentation/metal/mtlsharedeventnotificationblock>
 type MTLSharedEventNotificationBlock<'a> = RcBlock<(&'a SharedEventRef, u64), ()>;
 
+/// See <https://developer.apple.com/documentation/metal/mtlevent>
 pub enum MTLEvent {}
 
 foreign_obj_type! {
@@ -28,6 +30,7 @@ impl EventRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlsharedevent>
 pub enum MTLSharedEvent {}
 
 foreign_obj_type! {
@@ -81,6 +84,7 @@ impl SharedEventRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlsharedeventlistener>
 pub enum MTLSharedEventListener {}
 
 foreign_obj_type! {
@@ -108,6 +112,7 @@ impl SharedEventListener {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlfence>
 pub enum MTLFence {}
 
 foreign_obj_type! {

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -9,6 +9,7 @@ use super::*;
 
 use objc::runtime::{NO, YES};
 
+/// See <https://developer.apple.com/documentation/metal/mtltexturetype>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -23,6 +24,7 @@ pub enum MTLTextureType {
     D3 = 7,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtltexturecompressiontype>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum MTLTextureCompressionType {
@@ -31,6 +33,7 @@ pub enum MTLTextureCompressionType {
 }
 
 bitflags! {
+    /// See <https://developer.apple.com/documentation/metal/mtltextureusage>
     pub struct MTLTextureUsage: NSUInteger {
         const Unknown         = 0x0000;
         const ShaderRead      = 0x0001;
@@ -40,6 +43,7 @@ bitflags! {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtltexturedescriptor>
 pub enum MTLTextureDescriptor {}
 
 foreign_obj_type! {
@@ -173,6 +177,7 @@ impl TextureDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtltexture>
 pub enum MTLTexture {}
 
 foreign_obj_type! {

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,7 @@
 use super::NSUInteger;
 use std::default::Default;
 
+/// See <https://developer.apple.com/documentation/metal/mtlorigin>
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Default)]
 pub struct MTLOrigin {
@@ -16,6 +17,7 @@ pub struct MTLOrigin {
     pub z: NSUInteger,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlsize>
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Default)]
 pub struct MTLSize {
@@ -34,6 +36,7 @@ impl MTLSize {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlregion>
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Default)]
 pub struct MTLRegion {
@@ -72,6 +75,7 @@ impl MTLRegion {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlsampleposition>
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Default)]
 pub struct MTLSamplePosition {

--- a/src/vertexdescriptor.rs
+++ b/src/vertexdescriptor.rs
@@ -7,6 +7,7 @@
 
 use super::NSUInteger;
 
+/// See <https://developer.apple.com/documentation/metal/mtlvertexformat>
 #[repr(u64)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -65,6 +66,7 @@ pub enum MTLVertexFormat {
     Half = 53,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlvertexstepfunction>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLVertexStepFunction {
@@ -75,6 +77,7 @@ pub enum MTLVertexStepFunction {
     PerPatchControlPoint = 4,
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlvertexbufferlayoutdescriptor>
 pub enum MTLVertexBufferLayoutDescriptor {}
 
 foreign_obj_type! {
@@ -118,6 +121,7 @@ impl VertexBufferLayoutDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlvertexbufferlayoutdescriptorarray>
 pub enum MTLVertexBufferLayoutDescriptorArray {}
 
 foreign_obj_type! {
@@ -143,6 +147,7 @@ impl VertexBufferLayoutDescriptorArrayRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlvertexattributedescriptor>
 pub enum MTLVertexAttributeDescriptor {}
 
 foreign_obj_type! {
@@ -186,6 +191,7 @@ impl VertexAttributeDescriptorRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlvertexattributedescriptorarray>
 pub enum MTLVertexAttributeDescriptorArray {}
 
 foreign_obj_type! {
@@ -211,6 +217,7 @@ impl VertexAttributeDescriptorArrayRef {
     }
 }
 
+/// See <https://developer.apple.com/documentation/metal/mtlvertexdescriptor>
 pub enum MTLVertexDescriptor {}
 
 foreign_obj_type! {


### PR DESCRIPTION
1. Added links to Apple documentation for some structs, nearly all enums (except `MTLStructMemberArray` and `MTLStructMemberArray`), and some type definitions.
2. Explain away [docs.rs metal documentation](docs.rs/metal) build failure.
3. Add metal logo to README.
  a. I just think it looks nice, if it's not in the spirit of the project I'd be fine with it going :)