### PR TITLE
Add `is_null()` helper function to Texture

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -352,4 +352,14 @@ impl TextureRef {
     pub fn gpu_resource_id(&self) -> MTLResourceID {
         unsafe { msg_send![self, gpuResourceID] }
     }
+
+    pub fn is_null(&self) -> bool {
+        use foreign_types::ForeignTypeRef;
+
+        if self.as_ptr().is_null() {
+            true
+        } else {
+            false
+        }
+    }
 }


### PR DESCRIPTION
Avoid adding direct dependencies of the `foreign_types` crate in wgpu to determine if the Texture is NULL.

wgpu issue: https://github.com/gfx-rs/wgpu/issues/3153