### PR TITLE
Add `add_scheduled_handler` method to `CommandBuffer`

### DIFF
--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -101,6 +101,10 @@ impl CommandBufferRef {
         unsafe { msg_send![self, addCompletedHandler: block] }
     }
 
+    pub fn add_scheduled_handler(&self, block: &CommandBufferHandler) {
+        unsafe { msg_send![self, addScheduledHandler: block] }
+    }
+
     pub fn new_blit_command_encoder(&self) -> &BlitCommandEncoderRef {
         unsafe { msg_send![self, blitCommandEncoder] }
     }


### PR DESCRIPTION
This PR adds a binding for `MTLCommandBuffer` [addScheduledHandler](https://developer.apple.com/documentation/metal/mtlcommandbuffer/1442991-addscheduledhandler?language=objc).