### PR TITLE
Add `MTLTextureType::D2MultisampleArray`

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -22,6 +22,7 @@ pub enum MTLTextureType {
     Cube = 5,
     CubeArray = 6,
     D3 = 7,
+    D2MultisampleArray = 8,
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtltexturecompressiontype>


### PR DESCRIPTION
This PR adds a binding for the [`MTLTextureType2DMultisampleArray`](https://developer.apple.com/documentation/metal/mtltexturetype/mtltexturetype2dmultisamplearray?language=objc) texture type enum value.