### PR TITLE
Add MTLAccelerationStructureUserIDInstanceDescriptor

### DIFF
--- a/src/accelerator_structure.rs
+++ b/src/accelerator_structure.rs
@@ -28,6 +28,17 @@ pub struct MTLAccelerationStructureInstanceDescriptor {
     pub acceleration_structure_index: u32,
 }
 
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+#[repr(C)]
+pub struct MTLAccelerationStructureUserIDInstanceDescriptor {
+    pub transformation_matrix: [[f32; 3]; 4],
+    pub options: MTLAccelerationStructureInstanceOptions,
+    pub mask: u32,
+    pub intersection_function_table_offset: u32,
+    pub acceleration_structure_index: u32,
+    pub user_id: u32,
+}
+
 pub enum MTLAccelerationStructureDescriptor {}
 
 foreign_obj_type! {


### PR DESCRIPTION
Fairly straightforward.

Corresponding piece of "MTLAccelerationStructure.h":
```cpp
typedef struct {
    /**
     * @brief Transformation matrix describing how to transform the bottom-level acceleration structure.
     */
    MTLPackedFloat4x3 transformationMatrix;

    /**
     * @brief Instance options
     */
    MTLAccelerationStructureInstanceOptions options;

    /**
     * @brief Instance mask used to ignore geometry during ray tracing
     */
    uint32_t mask;

    /**
     * @brief Used to index into intersection function tables
     */
    uint32_t intersectionFunctionTableOffset;

    /**
     * @brief Acceleration structure index to use for this instance
     */
    uint32_t accelerationStructureIndex;

    /**
     * @brief User-assigned instance ID to help identify this instance in an
     * application-defined way
     */
    uint32_t userID;
} MTLAccelerationStructureUserIDInstanceDescriptor API_AVAILABLE(macos(12.0), ios(15.0));
```