### PR TITLE
chore: Fix timestamp bug and add required method

### DIFF
--- a/src/computepass.rs
+++ b/src/computepass.rs
@@ -72,7 +72,10 @@ impl ComputePassSampleBufferAttachmentDescriptorRef {
     }
 
     pub fn set_sample_buffer(&self, sample_buffer: &CounterSampleBufferRef) {
-        unsafe { msg_send![self, setSampleBuffer: sample_buffer] }
+        unsafe {
+            let () = msg_send![sample_buffer, retain];
+            msg_send![self, setSampleBuffer: sample_buffer]
+        }
     }
 
     pub fn start_of_encoder_sample_index(&self) -> NSUInteger {

--- a/src/computepass.rs
+++ b/src/computepass.rs
@@ -72,10 +72,7 @@ impl ComputePassSampleBufferAttachmentDescriptorRef {
     }
 
     pub fn set_sample_buffer(&self, sample_buffer: &CounterSampleBufferRef) {
-        unsafe {
-            let () = msg_send![sample_buffer, retain];
-            msg_send![self, setSampleBuffer: sample_buffer]
-        }
+        unsafe { msg_send![self, setSampleBuffer: sample_buffer] }
     }
 
     pub fn start_of_encoder_sample_index(&self) -> NSUInteger {

--- a/src/counters.rs
+++ b/src/counters.rs
@@ -25,11 +25,17 @@ impl CounterSampleBufferDescriptorRef {
     }
 
     pub fn label(&self) -> &str {
-        unsafe { msg_send![self, label] }
+        unsafe {
+            let label = msg_send![self, label];
+            crate::nsstring_as_str(label)
+        }
     }
 
     pub fn set_label(&self, label: &str) {
-        unsafe { msg_send![self, setLabel: label] }
+        unsafe {
+            let nslabel = crate::nsstring_from_str(label);
+            let () = msg_send![self, setLabel: nslabel];
+        }
     }
 
     pub fn sample_count(&self) -> u64 {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1395,6 +1395,23 @@ impl BlitCommandEncoderRef {
         unsafe { msg_send![self, waitForFence: fence] }
     }
 
+    /// See: <https://developer.apple.com/documentation/metal/mtlblitcommandencoder/3194348-samplecountersinbuffer>
+    pub fn sample_counters_in_buffer(
+        &self,
+        sample_buffer: &CounterSampleBufferRef,
+        sample_index: NSUInteger,
+        with_barrier: bool,
+    ) {
+        unsafe {
+            msg_send![self,
+                sampleCountersInBuffer: sample_buffer
+                atSampleIndex: sample_index
+                withBarrier: with_barrier
+            ]
+        }
+    }
+
+    /// See: <https://developer.apple.com/documentation/metal/mtlblitcommandencoder/3194347-resolvecounters>
     pub fn resolve_counters(
         &self,
         sample_buffer: &CounterSampleBufferRef,


### PR DESCRIPTION
Introduced a bug in the last PR.

Looks like everything should be good to go here, the retain is no longer needed thanks to @Wumpf.