### PR TITLE
Don't release the error obj manually

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,6 @@ macro_rules! try_objc {
                 let desc: *mut Object = msg_send![$err_name, localizedDescription];
                 let compile_error: *const std::os::raw::c_char = msg_send![desc, UTF8String];
                 let message = CStr::from_ptr(compile_error).to_string_lossy().into_owned();
-                let () = msg_send![$err_name, release];
                 return Err(message);
             }
             value


### PR DESCRIPTION
We should do this for the same reason it was done in: https://github.com/gfx-rs/metal-rs/pull/196 (calling functions which use this macro in an `autorelasepool` will cause a SIGSEGV since the obj has already been released manually).

Fixes the segfault encountered in: https://github.com/gfx-rs/wgpu/issues/3550.