### PR TITLE
Bump `bitflags` to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ mps = []
 
 [dependencies]
 core-graphics-types = "0.1"
-bitflags = "1"
+bitflags = "2"
 log = "0.4"
 block = "0.1.6"
 foreign-types = "0.5"

--- a/src/accelerator_structure.rs
+++ b/src/accelerator_structure.rs
@@ -8,7 +8,7 @@
 use super::*;
 
 bitflags! {
-    #[derive(Default)]
+    #[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLAccelerationStructureInstanceOptions: u32 {
         const None = 0;
         const DisableTriangleCulling = (1 << 0);

--- a/src/device.rs
+++ b/src/device.rs
@@ -94,6 +94,7 @@ pub enum MTLDeviceLocation {
 }
 
 bitflags! {
+    #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct PixelFormatCapabilities: u32 {
         const Filter = 1 << 0;
         const Write = 1 << 1;
@@ -1432,6 +1433,7 @@ pub enum MTLSparseTextureRegionAlignmentMode {
 
 bitflags! {
     /// Options that determine how Metal prepares the pipeline.
+    #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLPipelineOption: NSUInteger {
         /// Do not provide any reflection information.
         const None                      = 0;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -74,6 +74,7 @@ pub enum MTLTriangleFillMode {
 bitflags! {
     /// https://developer.apple.com/documentation/metal/mtlblitoption
     #[allow(non_upper_case_globals)]
+    #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLBlitOption: NSUInteger {
         /// https://developer.apple.com/documentation/metal/mtlblitoption/mtlblitoptionnone
         const None = 0;

--- a/src/indirect_encoder.rs
+++ b/src/indirect_encoder.rs
@@ -3,6 +3,7 @@ use super::*;
 bitflags! {
     /// See <https://developer.apple.com/documentation/metal/mtlindirectcommandtype/>
     #[allow(non_upper_case_globals)]
+    #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLIndirectCommandType: NSUInteger {
         const Draw                      = 1 << 0;
         const DrawIndexed               = 1 << 1;

--- a/src/library.rs
+++ b/src/library.rs
@@ -195,6 +195,7 @@ bitflags! {
     /// Only available on (macos(11.0), ios(14.0))
     ///
     /// See <https://developer.apple.com/documentation/metal/mtlfunctionoptions/>
+    #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLFunctionOptions: NSUInteger {
         const None = 0;
         const CompileToBinary = 1 << 0;

--- a/src/mps.rs
+++ b/src/mps.rs
@@ -40,6 +40,7 @@ pub enum MPSRayDataType {
 bitflags! {
     /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsraymaskoptions>
     #[allow(non_upper_case_globals)]
+    #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MPSRayMaskOptions: NSUInteger {
         /// Enable primitive masks
         const Primitive = 1;
@@ -115,6 +116,7 @@ pub enum MPSAccelerationStructureStatus {
 bitflags! {
     /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsaccelerationstructureusage>
     #[allow(non_upper_case_globals)]
+    #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MPSAccelerationStructureUsage: NSUInteger {
         /// No usage options specified
         const None = 0;

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -49,6 +49,7 @@ pub enum MTLBlendOperation {
 
 bitflags! {
     /// See <https://developer.apple.com/documentation/metal/mtlcolorwritemask>
+    #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLColorWriteMask: NSUInteger {
         const None  = 0;
         const Red   = 0x1 << 3;

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -58,6 +58,7 @@ pub const MTLResourceHazardTrackingModeMask: NSUInteger = 0x3 << MTLResourceHaza
 bitflags! {
     /// See <https://developer.apple.com/documentation/metal/mtlresourceoptions>
     #[allow(non_upper_case_globals)]
+    #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLResourceOptions: NSUInteger {
         const CPUCacheModeDefaultCache  = (MTLCPUCacheMode::DefaultCache as NSUInteger) << MTLResourceCPUCacheModeShift;
         const CPUCacheModeWriteCombined = (MTLCPUCacheMode::WriteCombined as NSUInteger) << MTLResourceCPUCacheModeShift;
@@ -83,6 +84,7 @@ bitflags! {
     /// convert the resource to another format (for example, whether to decompress a color render target).
     ///
     /// See <https://developer.apple.com/documentation/metal/mtlresourceusage>
+    #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLResourceUsage: NSUInteger {
         /// An option that enables reading from the resource.
         const Read   = 1 << 0;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -144,6 +144,7 @@ bitflags! {
     /// allowing for vertex and fragment processing to overlap in execution.
     ///
     /// See <https://developer.apple.com/documentation/metal/mtlrenderstages>
+    #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLRenderStages: NSUInteger {
         /// The vertex rendering stage.
         const Vertex = 1 << 0;

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -35,6 +35,7 @@ pub enum MTLTextureCompressionType {
 
 bitflags! {
     /// See <https://developer.apple.com/documentation/metal/mtltextureusage>
+    #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLTextureUsage: NSUInteger {
         const Unknown         = 0x0000;
         const ShaderRead      = 0x0001;


### PR DESCRIPTION
Changelog: https://github.com/bitflags/bitflags/blob/2.0.0/CHANGELOG.md#200.

This is a breaking change. The API that is implemented by the macro is now different.

I was a bit liberal with deriving `std` traits on public types, which mimics the behavior of `bitflags` v1, let me know if we don't need all these traits. Potentially we could at least drop `PartialOrd` and `Ord`.