### PR TITLE
Fix CI

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -65,7 +65,6 @@ impl SharedEventRef {
             (*block).flags |= BLOCK_HAS_SIGNATURE | BLOCK_HAS_COPY_DISPOSE;
             (*block).extra = &BLOCK_EXTRA;
             let () = msg_send![self, notifyListener:listener atValue:value block:block];
-            mem::forget(block);
         }
 
         extern "C" fn dtor(_: *mut BlockBase<(&SharedEventRef, u64), ()>) {}


### PR DESCRIPTION
CI is currently broken with:
```
error: calls to `std::mem::forget` with a value that implements `Copy` does nothing
Error:   --> src/sync.rs:68:13
   |
68 |             mem::forget(block);
   |             ^^^^^^^^^^^^-----^
   |                         |
   |                         argument has type `*mut BlockBase<(&SharedEventRef, u64), ()>`
```