### PR TITLE
Fix undefined behavior caused by calling Library::function_names()

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -670,7 +670,6 @@ impl LibraryRef {
                     nsstring_as_str(name).to_string()
                 })
                 .collect();
-            let () = msg_send![names, release];
             ret
         }
     }


### PR DESCRIPTION
I was getting crashes when interacting with libraries and I tracked it down to calling Library::function_names(). I barely understand the objc runtime and how rust binds with it, but I am suspicious that we are manually decrementing the ref count of an array of strings used internally by the MTLLibrary.

Here is example code that produced the crash consistently for me:

```rust
        let library = device
            .new_library_with_file("my_library.metallib")
            .unwrap();

        for function_name in library.function_names() {
            println!("metal function {}", function_name);
        }

        println!("dropping library");
        drop(library); // <-- Crashes if library.function_names() is called
        println!("it's dropped");
```

Before this change, I would crash in the `drop(library)` call. (Other interactions with the Library could also elicit odd crashes after calling `library.function_names()`).

Would appreciate a second opinion on this to confirm if my suspicion is well-placed. Docs for the bound function are here: https://developer.apple.com/documentation/metal/mtllibrary/1515651-functionnames