### PR TITLE
Fix unreachable pattern warnings on aarch64

### DIFF
--- a/src/argument.rs
+++ b/src/argument.rs
@@ -270,6 +270,7 @@ impl ArgumentRef {
             match msg_send![self, isActive] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -266,14 +266,7 @@ impl ArgumentRef {
     }
 
     pub fn is_active(&self) -> bool {
-        unsafe {
-            match msg_send![self, isActive] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isActive] }
     }
 
     pub fn buffer_alignment(&self) -> NSUInteger {

--- a/src/depthstencil.rs
+++ b/src/depthstencil.rs
@@ -134,6 +134,7 @@ impl DepthStencilDescriptorRef {
             match msg_send![self, isDepthWriteEnabled] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }

--- a/src/depthstencil.rs
+++ b/src/depthstencil.rs
@@ -130,14 +130,7 @@ impl DepthStencilDescriptorRef {
     }
 
     pub fn depth_write_enabled(&self) -> bool {
-        unsafe {
-            match msg_send![self, isDepthWriteEnabled] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isDepthWriteEnabled] }
     }
 
     pub fn set_depth_write_enabled(&self, enabled: bool) {

--- a/src/device.rs
+++ b/src/device.rs
@@ -1584,6 +1584,7 @@ impl DeviceRef {
             match msg_send![self, isLowPower] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -1594,6 +1595,7 @@ impl DeviceRef {
             match msg_send![self, isHeadless] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -1604,6 +1606,7 @@ impl DeviceRef {
             match msg_send![self, isRemovable] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -1615,6 +1618,7 @@ impl DeviceRef {
             match msg_send![self, supportsRaytracing] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -1625,6 +1629,7 @@ impl DeviceRef {
             match msg_send![self, hasUnifiedMemory] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -1643,6 +1648,7 @@ impl DeviceRef {
             match msg_send![self, supportsFeatureSet: feature] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -1653,6 +1659,7 @@ impl DeviceRef {
             match msg_send![self, supportsFamily: family] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -1663,6 +1670,7 @@ impl DeviceRef {
             match msg_send![self, supportsVertexAmplificationCount: count] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -1673,6 +1681,7 @@ impl DeviceRef {
             match msg_send![self, supportsTextureSampleCount: count] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -1683,6 +1692,7 @@ impl DeviceRef {
             match msg_send![self, supportsShaderBarycentricCoordinates] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -1693,6 +1703,7 @@ impl DeviceRef {
             match msg_send![self, supportsFunctionPointers] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -1704,6 +1715,7 @@ impl DeviceRef {
             match msg_send![self, supportsDynamicLibraries] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -1715,6 +1727,7 @@ impl DeviceRef {
             match msg_send![self, supportsCounterSampling: sampling_point] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -1725,6 +1738,7 @@ impl DeviceRef {
             match msg_send![self, isDepth24Stencil8PixelFormatSupported] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -2070,6 +2084,7 @@ impl DeviceRef {
             match msg_send![self, rasterOrderGroupsSupported] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -2081,6 +2096,7 @@ impl DeviceRef {
             match msg_send![self, supports32BitFloatFiltering] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -2092,6 +2108,7 @@ impl DeviceRef {
             match msg_send![self, supports32BitMSAA] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -2103,6 +2120,7 @@ impl DeviceRef {
             match msg_send![self, supportsQueryTextureLOD] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -2114,6 +2132,7 @@ impl DeviceRef {
             match msg_send![self, supportsBCTextureCompression] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -2125,6 +2144,7 @@ impl DeviceRef {
             match msg_send![self, supportsPullModelInterpolation] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1580,59 +1580,24 @@ impl DeviceRef {
     }
 
     pub fn is_low_power(&self) -> bool {
-        unsafe {
-            match msg_send![self, isLowPower] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isLowPower] }
     }
 
     pub fn is_headless(&self) -> bool {
-        unsafe {
-            match msg_send![self, isHeadless] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isHeadless] }
     }
 
     pub fn is_removable(&self) -> bool {
-        unsafe {
-            match msg_send![self, isRemovable] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isRemovable] }
     }
 
     /// Only available on (macos(11.0), ios(14.0))
     pub fn supports_raytracing(&self) -> bool {
-        unsafe {
-            match msg_send![self, supportsRaytracing] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportsRaytracing] }
     }
 
     pub fn has_unified_memory(&self) -> bool {
-        unsafe {
-            match msg_send![self, hasUnifiedMemory] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send![self, hasUnifiedMemory] }
     }
 
     pub fn recommended_max_working_set_size(&self) -> u64 {
@@ -1644,104 +1609,41 @@ impl DeviceRef {
     }
 
     pub fn supports_feature_set(&self, feature: MTLFeatureSet) -> bool {
-        unsafe {
-            match msg_send![self, supportsFeatureSet: feature] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportsFeatureSet: feature] }
     }
 
     pub fn supports_family(&self, family: MTLGPUFamily) -> bool {
-        unsafe {
-            match msg_send![self, supportsFamily: family] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportsFamily: family] }
     }
 
     pub fn supports_vertex_amplification_count(&self, count: NSUInteger) -> bool {
-        unsafe {
-            match msg_send![self, supportsVertexAmplificationCount: count] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportsVertexAmplificationCount: count] }
     }
 
     pub fn supports_texture_sample_count(&self, count: NSUInteger) -> bool {
-        unsafe {
-            match msg_send![self, supportsTextureSampleCount: count] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportsTextureSampleCount: count] }
     }
 
     pub fn supports_shader_barycentric_coordinates(&self) -> bool {
-        unsafe {
-            match msg_send![self, supportsShaderBarycentricCoordinates] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportsShaderBarycentricCoordinates] }
     }
 
     pub fn supports_function_pointers(&self) -> bool {
-        unsafe {
-            match msg_send![self, supportsFunctionPointers] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportsFunctionPointers] }
     }
 
     /// Only available on (macos(11.0), ios(14.0))
     pub fn supports_dynamic_libraries(&self) -> bool {
-        unsafe {
-            match msg_send![self, supportsDynamicLibraries] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportsDynamicLibraries] }
     }
 
     /// Only available on (macos(11.0), ios(14.0))
     pub fn supports_counter_sampling(&self, sampling_point: MTLCounterSamplingPoint) -> bool {
-        unsafe {
-            match msg_send![self, supportsCounterSampling: sampling_point] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportsCounterSampling: sampling_point] }
     }
 
     pub fn d24_s8_supported(&self) -> bool {
-        unsafe {
-            match msg_send![self, isDepth24Stencil8PixelFormatSupported] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isDepth24Stencil8PixelFormatSupported] }
     }
 
     pub fn new_fence(&self) -> Fence {
@@ -2080,74 +1982,32 @@ impl DeviceRef {
     }
 
     pub fn raster_order_groups_supported(&self) -> bool {
-        unsafe {
-            match msg_send![self, rasterOrderGroupsSupported] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, rasterOrderGroupsSupported] }
     }
 
     /// Only available on (macos(11.0), ios(14.0))
     pub fn supports_32bit_float_filtering(&self) -> bool {
-        unsafe {
-            match msg_send![self, supports32BitFloatFiltering] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supports32BitFloatFiltering] }
     }
 
     /// Only available on (macos(11.0), ios(14.0))
     pub fn supports_32bit_MSAA(&self) -> bool {
-        unsafe {
-            match msg_send![self, supports32BitMSAA] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supports32BitMSAA] }
     }
 
     /// Only available on (macos(11.0), ios(14.0))
     pub fn supports_query_texture_LOD(&self) -> bool {
-        unsafe {
-            match msg_send![self, supportsQueryTextureLOD] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportsQueryTextureLOD] }
     }
 
     /// Only available on (macos(11.0), ios(14.0))
     pub fn supports_BC_texture_compression(&self) -> bool {
-        unsafe {
-            match msg_send![self, supportsBCTextureCompression] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportsBCTextureCompression] }
     }
 
     /// Only available on (macos(11.0), ios(14.0))
     pub fn supports_pull_model_interpolation(&self) -> bool {
-        unsafe {
-            match msg_send![self, supportsPullModelInterpolation] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportsPullModelInterpolation] }
     }
 
     pub fn new_argument_encoder(

--- a/src/indirect_encoder.rs
+++ b/src/indirect_encoder.rs
@@ -32,14 +32,7 @@ impl IndirectCommandBufferDescriptorRef {
     }
 
     pub fn inherit_buffers(&self) -> bool {
-        unsafe {
-            match msg_send![self, inheritBuffers] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, inheritBuffers] }
     }
 
     pub fn set_inherit_buffers(&self, inherit: bool) {
@@ -47,14 +40,7 @@ impl IndirectCommandBufferDescriptorRef {
     }
 
     pub fn inherit_pipeline_state(&self) -> bool {
-        unsafe {
-            match msg_send![self, inheritPipelineState] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, inheritPipelineState] }
     }
 
     pub fn set_inherit_pipeline_state(&self, inherit: bool) {

--- a/src/indirect_encoder.rs
+++ b/src/indirect_encoder.rs
@@ -36,6 +36,7 @@ impl IndirectCommandBufferDescriptorRef {
             match msg_send![self, inheritBuffers] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -50,6 +51,7 @@ impl IndirectCommandBufferDescriptorRef {
             match msg_send![self, inheritPipelineState] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,46 @@ macro_rules! try_objc {
     };
 }
 
+macro_rules! msg_send_bool {
+    ($obj:expr, $name:ident) => {{
+        match msg_send![$obj, $name] {
+            YES => true,
+            NO => false,
+            #[cfg(not(target_arch = "aarch64"))]
+            _ => unreachable!(),
+        }
+    }};
+    ($obj:expr, $name:ident : $arg:expr) => {{
+        match msg_send![$obj, $name: $arg] {
+            YES => true,
+            NO => false,
+            #[cfg(not(target_arch = "aarch64"))]
+            _ => unreachable!(),
+        }
+    }};
+}
+
+macro_rules! msg_send_bool_error_check {
+    ($obj:expr, $name:ident: $arg:expr) => {{
+        let mut err: *mut Object = ptr::null_mut();
+        let result: BOOL = msg_send![$obj, $name:$arg
+                                                    error:&mut err];
+        if !err.is_null() {
+            let desc: *mut Object = msg_send![err, localizedDescription];
+            let c_msg: *const c_char = msg_send![desc, UTF8String];
+            let message = CStr::from_ptr(c_msg).to_string_lossy().into_owned();
+            Err(message)
+        } else {
+            match result {
+                YES => Ok(true),
+                NO => Ok(false),
+                #[cfg(not(target_arch = "aarch64"))]
+                _ => unreachable!(),
+            }
+        }
+    }};
+}
+
 /// See <https://developer.apple.com/documentation/foundation/nsarray>
 pub struct NSArray<T> {
     _phantom: PhantomData<T>,
@@ -425,14 +465,7 @@ impl MetalLayerRef {
     }
 
     pub fn presents_with_transaction(&self) -> bool {
-        unsafe {
-            match msg_send![self, presentsWithTransaction] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, presentsWithTransaction] }
     }
 
     pub fn set_presents_with_transaction(&self, transaction: bool) {
@@ -440,14 +473,7 @@ impl MetalLayerRef {
     }
 
     pub fn display_sync_enabled(&self) -> bool {
-        unsafe {
-            match msg_send![self, displaySyncEnabled] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, displaySyncEnabled] }
     }
 
     pub fn set_display_sync_enabled(&self, enabled: bool) {
@@ -488,14 +514,7 @@ impl MetalLayerRef {
 
     /// [framebufferOnly Apple Docs](https://developer.apple.com/documentation/metal/mtltexture/1515749-framebufferonly?language=objc)
     pub fn framebuffer_only(&self) -> bool {
-        unsafe {
-            match msg_send![self, framebufferOnly] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool!(self, framebufferOnly) }
     }
 
     pub fn set_framebuffer_only(&self, framebuffer_only: bool) {
@@ -503,14 +522,7 @@ impl MetalLayerRef {
     }
 
     pub fn is_opaque(&self) -> bool {
-        unsafe {
-            match msg_send![self, isOpaque] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool!(self, isOpaque) }
     }
 
     pub fn set_opaque(&self, opaque: bool) {
@@ -518,14 +530,7 @@ impl MetalLayerRef {
     }
 
     pub fn wants_extended_dynamic_range_content(&self) -> bool {
-        unsafe {
-            match msg_send![self, wantsExtendedDynamicRangeContent] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, wantsExtendedDynamicRangeContent] }
     }
 
     pub fn set_wants_extended_dynamic_range_content(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,6 +429,7 @@ impl MetalLayerRef {
             match msg_send![self, presentsWithTransaction] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -443,6 +444,7 @@ impl MetalLayerRef {
             match msg_send![self, displaySyncEnabled] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -490,6 +492,7 @@ impl MetalLayerRef {
             match msg_send![self, framebufferOnly] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -504,6 +507,7 @@ impl MetalLayerRef {
             match msg_send![self, isOpaque] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -518,6 +522,7 @@ impl MetalLayerRef {
             match msg_send![self, wantsExtendedDynamicRangeContent] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }

--- a/src/library.rs
+++ b/src/library.rs
@@ -50,38 +50,17 @@ impl VertexAttributeRef {
     }
 
     pub fn is_active(&self) -> bool {
-        unsafe {
-            match msg_send![self, isActive] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isActive] }
     }
 
     /// Only available on (macos(10.12), ios(10.0)
     pub fn is_patch_data(&self) -> bool {
-        unsafe {
-            match msg_send![self, isPatchData] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isPatchData] }
     }
 
     /// Only available on (macos(10.12), ios(10.0)
     pub fn is_patch_control_point_data(&self) -> bool {
-        unsafe {
-            match msg_send![self, isPatchControlPointData] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isPatchControlPointData] }
     }
 }
 
@@ -112,38 +91,17 @@ impl AttributeRef {
     }
 
     pub fn is_active(&self) -> bool {
-        unsafe {
-            match msg_send![self, isActive] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isActive] }
     }
 
     /// Only available on (macos(10.12), ios(10.0))
     pub fn is_patch_data(&self) -> bool {
-        unsafe {
-            match msg_send![self, isPatchData] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isPatchData] }
     }
 
     /// Only available on (macos(10.12), ios(10.0))
     pub fn is_patch_control_point_data(&self) -> bool {
-        unsafe {
-            match msg_send![self, isPatchControlPointData] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isPatchControlPointData] }
     }
 }
 
@@ -187,14 +145,7 @@ impl FunctionConstantRef {
     }
 
     pub fn required(&self) -> bool {
-        unsafe {
-            match msg_send![self, required] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, required] }
     }
 }
 
@@ -493,14 +444,7 @@ impl CompileOptionsRef {
     }
 
     pub fn is_fast_math_enabled(&self) -> bool {
-        unsafe {
-            match msg_send![self, fastMathEnabled] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, fastMathEnabled] }
     }
 
     pub fn set_fast_math_enabled(&self, enabled: bool) {
@@ -584,14 +528,7 @@ impl CompileOptionsRef {
 
     /// Only available on (macos(11.0), macCatalyst(14.0), ios(13.0))
     pub fn preserve_invariance(&self) -> bool {
-        unsafe {
-            match msg_send![self, preserveInvariance] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, preserveInvariance] }
     }
 
     /// Only available on (macos(11.0), macCatalyst(14.0), ios(13.0))
@@ -790,25 +727,7 @@ impl DynamicLibraryRef {
     }
 
     pub fn serialize_to_url(&self, url: &URLRef) -> Result<bool, String> {
-        unsafe {
-            let mut err: *mut Object = ptr::null_mut();
-            let result: BOOL = msg_send![self, serializeToURL:url
-                                                        error:&mut err];
-            if !err.is_null() {
-                // FIXME: copy pasta
-                let desc: *mut Object = msg_send![err, localizedDescription];
-                let c_msg: *const c_char = msg_send![desc, UTF8String];
-                let message = CStr::from_ptr(c_msg).to_string_lossy().into_owned();
-                Err(message)
-            } else {
-                match result {
-                    YES => Ok(true),
-                    NO => Ok(false),
-                    #[cfg(not(target_arch = "aarch64"))]
-                    _ => unreachable!(),
-                }
-            }
-        }
+        unsafe { msg_send_bool_error_check![self, serializeToURL: url] }
     }
 }
 
@@ -874,23 +793,7 @@ impl BinaryArchiveRef {
         descriptor: &ComputePipelineDescriptorRef,
     ) -> Result<bool, String> {
         unsafe {
-            let mut err: *mut Object = ptr::null_mut();
-            let result: BOOL = msg_send![self, addComputePipelineFunctionsWithDescriptor:descriptor
-                                                                        error:&mut err];
-            if !err.is_null() {
-                // FIXME: copy pasta
-                let desc: *mut Object = msg_send![err, localizedDescription];
-                let c_msg: *const c_char = msg_send![desc, UTF8String];
-                let message = CStr::from_ptr(c_msg).to_string_lossy().into_owned();
-                Err(message)
-            } else {
-                match result {
-                    YES => Ok(true),
-                    NO => Ok(false),
-                    #[cfg(not(target_arch = "aarch64"))]
-                    _ => unreachable!(),
-                }
-            }
+            msg_send_bool_error_check![self, addComputePipelineFunctionsWithDescriptor: descriptor]
         }
     }
 
@@ -899,23 +802,7 @@ impl BinaryArchiveRef {
         descriptor: &RenderPipelineDescriptorRef,
     ) -> Result<bool, String> {
         unsafe {
-            let mut err: *mut Object = ptr::null_mut();
-            let result: BOOL = msg_send![self, addRenderPipelineFunctionsWithDescriptor:descriptor
-                                                                        error:&mut err];
-            if !err.is_null() {
-                // FIXME: copy pasta
-                let desc: *mut Object = msg_send![err, localizedDescription];
-                let c_msg: *const c_char = msg_send![desc, UTF8String];
-                let message = CStr::from_ptr(c_msg).to_string_lossy().into_owned();
-                Err(message)
-            } else {
-                match result {
-                    YES => Ok(true),
-                    NO => Ok(false),
-                    #[cfg(not(target_arch = "aarch64"))]
-                    _ => unreachable!(),
-                }
-            }
+            msg_send_bool_error_check![self, addRenderPipelineFunctionsWithDescriptor: descriptor]
         }
     }
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -54,6 +54,7 @@ impl VertexAttributeRef {
             match msg_send![self, isActive] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -65,6 +66,7 @@ impl VertexAttributeRef {
             match msg_send![self, isPatchData] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -76,6 +78,7 @@ impl VertexAttributeRef {
             match msg_send![self, isPatchControlPointData] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -113,6 +116,7 @@ impl AttributeRef {
             match msg_send![self, isActive] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -124,6 +128,7 @@ impl AttributeRef {
             match msg_send![self, isPatchData] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -135,6 +140,7 @@ impl AttributeRef {
             match msg_send![self, isPatchControlPointData] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -185,6 +191,7 @@ impl FunctionConstantRef {
             match msg_send![self, required] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -490,6 +497,7 @@ impl CompileOptionsRef {
             match msg_send![self, fastMathEnabled] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -580,6 +588,7 @@ impl CompileOptionsRef {
             match msg_send![self, preserveInvariance] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -795,6 +804,7 @@ impl DynamicLibraryRef {
                 match result {
                     YES => Ok(true),
                     NO => Ok(false),
+                    #[cfg(not(target_arch = "aarch64"))]
                     _ => unreachable!(),
                 }
             }
@@ -877,6 +887,7 @@ impl BinaryArchiveRef {
                 match result {
                     YES => Ok(true),
                     NO => Ok(false),
+                    #[cfg(not(target_arch = "aarch64"))]
                     _ => unreachable!(),
                 }
             }
@@ -901,6 +912,7 @@ impl BinaryArchiveRef {
                 match result {
                     YES => Ok(true),
                     NO => Ok(false),
+                    #[cfg(not(target_arch = "aarch64"))]
                     _ => unreachable!(),
                 }
             }
@@ -926,6 +938,7 @@ impl BinaryArchiveRef {
                 match result {
                     YES => Ok(true),
                     NO => Ok(false),
+                    #[cfg(not(target_arch = "aarch64"))]
                     _ => unreachable!(),
                 }
             }

--- a/src/pipeline/compute.rs
+++ b/src/pipeline/compute.rs
@@ -125,14 +125,7 @@ impl ComputePipelineDescriptorRef {
     }
 
     pub fn thread_group_size_is_multiple_of_thread_execution_width(&self) -> bool {
-        unsafe {
-            match msg_send![self, threadGroupSizeIsMultipleOfThreadExecutionWidth] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, threadGroupSizeIsMultipleOfThreadExecutionWidth] }
     }
 
     pub fn set_thread_group_size_is_multiple_of_thread_execution_width(
@@ -159,14 +152,7 @@ impl ComputePipelineDescriptorRef {
 
     /// API_AVAILABLE(ios(13.0),macos(11.0));
     pub fn support_indirect_command_buffers(&self) -> bool {
-        unsafe {
-            match msg_send![self, supportIndirectCommandBuffers] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportIndirectCommandBuffers] }
     }
 
     /// API_AVAILABLE(ios(13.0),macos(11.0));
@@ -176,14 +162,7 @@ impl ComputePipelineDescriptorRef {
 
     /// API_AVAILABLE(macos(11.0), ios(14.0));
     pub fn support_adding_binary_functions(&self) -> bool {
-        unsafe {
-            match msg_send![self, supportAddingBinaryFunctions] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportAddingBinaryFunctions] }
     }
 
     /// API_AVAILABLE(macos(11.0), ios(14.0));
@@ -308,14 +287,7 @@ impl ComputePipelineStateRef {
 
     /// Only available on (ios(13.0), macos(11.0))
     pub fn support_indirect_command_buffers(&self) -> bool {
-        unsafe {
-            match msg_send![self, supportIndirectCommandBuffers] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportIndirectCommandBuffers] }
     }
 
     /// Only available on (macos(11.0), ios(14.0))

--- a/src/pipeline/compute.rs
+++ b/src/pipeline/compute.rs
@@ -129,6 +129,7 @@ impl ComputePipelineDescriptorRef {
             match msg_send![self, threadGroupSizeIsMultipleOfThreadExecutionWidth] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -162,6 +163,7 @@ impl ComputePipelineDescriptorRef {
             match msg_send![self, supportIndirectCommandBuffers] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -178,6 +180,7 @@ impl ComputePipelineDescriptorRef {
             match msg_send![self, supportAddingBinaryFunctions] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -309,6 +312,7 @@ impl ComputePipelineStateRef {
             match msg_send![self, supportIndirectCommandBuffers] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -94,14 +94,7 @@ impl RenderPipelineColorAttachmentDescriptorRef {
     }
 
     pub fn is_blending_enabled(&self) -> bool {
-        unsafe {
-            match msg_send![self, isBlendingEnabled] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isBlendingEnabled] }
     }
 
     pub fn set_blending_enabled(&self, enabled: bool) {
@@ -292,14 +285,7 @@ impl MeshRenderPipelineDescriptorRef {
     }
 
     pub fn is_alpha_to_coverage_enabled(&self) -> bool {
-        unsafe {
-            match msg_send![self, isAlphaToCoverageEnabled] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isAlphaToCoverageEnabled] }
     }
 
     pub fn set_alpha_to_coverage_enabled(&self, enabled: bool) {
@@ -307,14 +293,7 @@ impl MeshRenderPipelineDescriptorRef {
     }
 
     pub fn is_alpha_to_one_enabled(&self) -> bool {
-        unsafe {
-            match msg_send![self, isAlphaToOneEnabled] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isAlphaToOneEnabled] }
     }
 
     pub fn set_alpha_to_one_enabled(&self, enabled: bool) {
@@ -322,14 +301,7 @@ impl MeshRenderPipelineDescriptorRef {
     }
 
     pub fn is_rasterization_enabled(&self) -> bool {
-        unsafe {
-            match msg_send![self, isRasterizationEnabled] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isRasterizationEnabled] }
     }
 
     pub fn set_rasterization_enabled(&self, enabled: bool) {
@@ -424,14 +396,7 @@ impl MeshRenderPipelineDescriptorRef {
     }
 
     pub fn mesh_threadgroup_size_is_multiple_of_thread_execution_width(&self) -> bool {
-        unsafe {
-            match msg_send![self, isMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth] }
     }
 
     pub fn set_mesh_threadgroup_size_is_multiple_of_thread_execution_width(
@@ -461,15 +426,10 @@ impl MeshRenderPipelineDescriptorRef {
 
     pub fn object_threadgroup_size_is_multiple_of_thread_execution_width(&self) -> bool {
         unsafe {
-            match msg_send![
+            msg_send_bool![
                 self,
                 isObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth
-            ] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
+            ]
         }
     }
 
@@ -598,14 +558,7 @@ impl RenderPipelineDescriptorRef {
     }
 
     pub fn is_alpha_to_coverage_enabled(&self) -> bool {
-        unsafe {
-            match msg_send![self, isAlphaToCoverageEnabled] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isAlphaToCoverageEnabled] }
     }
 
     pub fn set_alpha_to_coverage_enabled(&self, enabled: bool) {
@@ -613,14 +566,7 @@ impl RenderPipelineDescriptorRef {
     }
 
     pub fn is_alpha_to_one_enabled(&self) -> bool {
-        unsafe {
-            match msg_send![self, isAlphaToOneEnabled] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isAlphaToOneEnabled] }
     }
 
     pub fn set_alpha_to_one_enabled(&self, enabled: bool) {
@@ -628,14 +574,7 @@ impl RenderPipelineDescriptorRef {
     }
 
     pub fn is_rasterization_enabled(&self) -> bool {
-        unsafe {
-            match msg_send![self, isRasterizationEnabled] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isRasterizationEnabled] }
     }
 
     pub fn set_rasterization_enabled(&self, enabled: bool) {
@@ -685,14 +624,7 @@ impl RenderPipelineDescriptorRef {
     }
 
     pub fn support_indirect_command_buffers(&self) -> bool {
-        unsafe {
-            match msg_send![self, supportIndirectCommandBuffers] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, supportIndirectCommandBuffers] }
     }
 
     pub fn set_support_indirect_command_buffers(&self, support: bool) {

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -98,6 +98,7 @@ impl RenderPipelineColorAttachmentDescriptorRef {
             match msg_send![self, isBlendingEnabled] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -295,6 +296,7 @@ impl MeshRenderPipelineDescriptorRef {
             match msg_send![self, isAlphaToCoverageEnabled] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -309,6 +311,7 @@ impl MeshRenderPipelineDescriptorRef {
             match msg_send![self, isAlphaToOneEnabled] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -323,6 +326,7 @@ impl MeshRenderPipelineDescriptorRef {
             match msg_send![self, isRasterizationEnabled] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -424,6 +428,7 @@ impl MeshRenderPipelineDescriptorRef {
             match msg_send![self, isMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -462,6 +467,7 @@ impl MeshRenderPipelineDescriptorRef {
             ] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -596,6 +602,7 @@ impl RenderPipelineDescriptorRef {
             match msg_send![self, isAlphaToCoverageEnabled] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -610,6 +617,7 @@ impl RenderPipelineDescriptorRef {
             match msg_send![self, isAlphaToOneEnabled] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -624,6 +632,7 @@ impl RenderPipelineDescriptorRef {
             match msg_send![self, isRasterizationEnabled] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }
@@ -680,6 +689,7 @@ impl RenderPipelineDescriptorRef {
             match msg_send![self, supportIndirectCommandBuffers] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -181,6 +181,7 @@ impl ResourceRef {
             match msg_send![self, isAliasable] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -177,13 +177,6 @@ impl ResourceRef {
 
     /// Only available on macos(10.13), ios(10.0)
     pub fn is_aliasable(&self) -> bool {
-        unsafe {
-            match msg_send![self, isAliasable] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isAliasable] }
     }
 }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -259,6 +259,7 @@ impl TextureRef {
             match msg_send![self, isFramebufferOnly] {
                 YES => true,
                 NO => false,
+                #[cfg(not(target_arch = "aarch64"))]
                 _ => unreachable!(),
             }
         }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -255,14 +255,7 @@ impl TextureRef {
 
     /// [framebufferOnly Apple Docs](https://developer.apple.com/documentation/metal/mtltexture/1515749-framebufferonly?language=objc)
     pub fn framebuffer_only(&self) -> bool {
-        unsafe {
-            match msg_send![self, isFramebufferOnly] {
-                YES => true,
-                NO => false,
-                #[cfg(not(target_arch = "aarch64"))]
-                _ => unreachable!(),
-            }
-        }
+        unsafe { msg_send_bool![self, isFramebufferOnly] }
     }
 
     pub fn get_bytes(


### PR DESCRIPTION
This fixes `warning: unreachable pattern` on `aarch64`, as seen when running e.g. `cargo clippy` or `cargo run --example compute`.

As suggested by [this comment](https://github.com/gfx-rs/metal-rs/pull/267#issuecomment-1509633887) in #267 (which this PR replaces).