### PR TITLE
Replace unmaintained actions-rs GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions-rs/cargo@v1
-
-    - name: Select Rust channel
-      uses: actions-rs/toolchain@v1
+    - name: Setup rust toolchain
+      uses: dtolnay/rust-toolchain@stable
       with:
-          toolchain: ${{ matrix.channel }}
-          override: true
+        toolchain: ${{ matrix.channel }}
 
     - name: Rust Version Info
       run: rustc --version && cargo --version


### PR DESCRIPTION
The [actions-rs/cargo](https://github.com/actions-rs/cargo) and [actions-rs/toolchain](https://github.com/actions-rs/toolchain) are not maintained - replace them with [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain).

Motivated by the build failure in https://github.com/gfx-rs/metal-rs/actions/runs/5468319428/jobs/9955791906 (probably caused by [actions using node.js 12 starting to break](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)).