### PR TITLE
build(docs.rs): cover more Mac targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,13 @@ edition = "2021"
 exclude = ["guide/**/*", "examples/texture/**/*", "tests/**/*", "Cargo.lock", "target/**/*"]
 
 [package.metadata.docs.rs]
-default-target = "x86_64-apple-darwin"
+targets = [
+  "aarch64-apple-darwin", # presented first in Docs.rs, keep this here
+  "aarch64-apple-ios",
+  "aarch64-apple-ios-sim",
+  "x86_64-apple-darwin",
+  "x86_64-apple-ios",
+]
 
 [features]
 default = ["link"]


### PR DESCRIPTION
Expands the set of Mac targets to cover more Mac toolchains. 😀

<details><summary>Original OP text from draft</summary>

We've specified a `default-target` for `docs.rs` metadata in `Cargo.toml`, but the way to exclude other platforms is via the `targets` field, according to [these docs][targets-docs] on it:

> ```
> # If `default-target` is unset, the first element of `targets` is treated as the default target.
> # Otherwise, these `targets` are built in addition to the default target.
> # If both `default-target` and `targets` are unset,
> #   all tier-one targets will be built and `x86_64-unknown-linux-gnu` will be used as the default target.
> ```

[targets-docs]: https://web.archive.org/web/20230528205129/https://docs.rs/about/metadata

---

~~Should fix #5.~~ EDIT: [Maybe not?](https://github.com/gfx-rs/metal-rs/pull/276#issuecomment-1636313550)

</details>
