### PR TITLE
Add support for creating and using indirect command buffers

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1958,6 +1958,19 @@ impl DeviceRef {
         }
     }
 
+    pub fn new_indirect_command_buffer_with_descriptor(
+        &self,
+        descriptor: &IndirectCommandBufferDescriptorRef,
+        max_command_count: NSUInteger,
+        options: MTLResourceOptions,
+    ) -> IndirectCommandBuffer {
+        unsafe {
+            msg_send![self, newIndirectCommandBufferWithDescriptor:descriptor
+                                                   maxCommandCount:max_command_count
+                                                           options:options]
+        }
+    }
+
     pub fn new_texture(&self, descriptor: &TextureDescriptorRef) -> Texture {
         unsafe { msg_send![self, newTextureWithDescriptor: descriptor] }
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1396,6 +1396,45 @@ impl BlitCommandEncoderRef {
         unsafe { msg_send![self, waitForFence: fence] }
     }
 
+    pub fn copy_indirect_command_buffer(
+        &self,
+        source: &IndirectCommandBufferRef,
+        source_range: NSRange,
+        destination: &IndirectCommandBufferRef,
+        destination_index: NSUInteger,
+    ) {
+        unsafe {
+            msg_send![self,
+                copyIndirectCommandBuffer: source
+                sourceRange: source_range
+                destination: destination
+                destinationIndex: destination_index
+            ]
+        }
+    }
+
+    pub fn reset_commands_in_buffer(&self, buffer: &IndirectCommandBufferRef, range: NSRange) {
+        unsafe {
+            msg_send![self,
+                resetCommandsInBuffer: buffer
+                withRange: range
+            ]
+        }
+    }
+
+    pub fn optimize_indirect_command_buffer(
+        &self,
+        buffer: &IndirectCommandBufferRef,
+        range: NSRange,
+    ) {
+        unsafe {
+            msg_send![self,
+                optimizeIndirectCommandBuffer: buffer
+                withRange: range
+            ]
+        }
+    }
+
     /// See: <https://developer.apple.com/documentation/metal/mtlblitcommandencoder/3194348-samplecountersinbuffer>
     pub fn sample_counters_in_buffer(
         &self,
@@ -1859,6 +1898,35 @@ impl ArgumentEncoderRef {
 
     pub fn constant_data(&self, at_index: NSUInteger) -> *mut std::ffi::c_void {
         unsafe { msg_send![self, constantDataAtIndex: at_index] }
+    }
+
+    pub fn set_indirect_command_buffer(
+        &self,
+        at_index: NSUInteger,
+        buffer: &IndirectCommandBufferRef,
+    ) {
+        unsafe {
+            msg_send![self,
+                setIndirectCommandBuffer: buffer
+                atIndex: at_index
+            ]
+        }
+    }
+
+    pub fn set_indirect_command_buffers(
+        &self,
+        start_index: NSUInteger,
+        data: &[&IndirectCommandBufferRef],
+    ) {
+        unsafe {
+            msg_send![self,
+                setIndirectCommandBuffers: data.as_ptr()
+                withRange: NSRange {
+                    location: start_index,
+                    length: data.len() as _,
+                }
+            ]
+        }
     }
 
     pub fn new_argument_encoder_for_buffer(&self, index: NSUInteger) -> ArgumentEncoder {

--- a/src/indirect_encoder.rs
+++ b/src/indirect_encoder.rs
@@ -22,6 +22,13 @@ foreign_obj_type! {
     pub struct IndirectCommandBufferDescriptor;
 }
 
+impl IndirectCommandBufferDescriptor {
+    pub fn new() -> Self {
+        let class = class!(MTLIndirectCommandBufferDescriptor);
+        unsafe { msg_send![class, new] }
+    }
+}
+
 impl IndirectCommandBufferDescriptorRef {
     pub fn command_types(&self) -> MTLIndirectCommandType {
         unsafe { msg_send![self, commandTypes] }


### PR DESCRIPTION
Added:
 - `Device::new_indirect_command_buffer_with_descriptor`
 - `IndirectCommandBufferDescriptor::new`
 - `BlitCommandEncoder::copy_indirect_command_buffer`
 - `BlitCommandEncoder::reset_commands_in_buffer`
 - `BlitCommandEncoder::optimize_indirect_command_buffer`
 - `ArgumentEncoder::set_indirect_command_buffer`
 - `ArgumentEncoder::set_indirect_command_buffers`

This makes indirect command buffers usable from metal-rs

Fixes #278 