### PR TITLE
More timer query support

### DIFF
--- a/src/blitpass.rs
+++ b/src/blitpass.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+/// See <https://developer.apple.com/documentation/metal/mtlblitpassdescriptor>
+pub enum MTLBlitPassDescriptor {}
+
+foreign_obj_type! {
+    type CType = MTLBlitPassDescriptor;
+    pub struct BlitPassDescriptor;
+}
+
+impl BlitPassDescriptor {
+    /// Creates a default blit command pass descriptor with no attachments.
+    pub fn new<'a>() -> &'a BlitPassDescriptorRef {
+        unsafe { msg_send![class!(MTLBlitPassDescriptor), blitPassDescriptor] }
+    }
+}
+
+impl BlitPassDescriptorRef {
+    // See <https://developer.apple.com/documentation/metal/mtlblitpassdescriptor>
+    pub fn sample_buffer_attachments(&self) -> &BlitPassSampleBufferAttachmentDescriptorArrayRef {
+        unsafe { msg_send![self, sampleBufferAttachments] }
+    }
+}
+
+/// See <https://developer.apple.com/documentation/metal/mtlblitpasssamplebufferattachmentdescriptorarray>
+pub enum MTLBlitPassSampleBufferAttachmentDescriptorArray {}
+
+foreign_obj_type! {
+    type CType = MTLBlitPassSampleBufferAttachmentDescriptorArray;
+    pub struct BlitPassSampleBufferAttachmentDescriptorArray;
+}
+
+impl BlitPassSampleBufferAttachmentDescriptorArrayRef {
+    pub fn object_at(
+        &self,
+        index: NSUInteger,
+    ) -> Option<&BlitPassSampleBufferAttachmentDescriptorRef> {
+        unsafe { msg_send![self, objectAtIndexedSubscript: index] }
+    }
+
+    pub fn set_object_at(
+        &self,
+        index: NSUInteger,
+        attachment: Option<&BlitPassSampleBufferAttachmentDescriptorRef>,
+    ) {
+        unsafe {
+            msg_send![self, setObject:attachment
+                     atIndexedSubscript:index]
+        }
+    }
+}
+
+/// See <https://developer.apple.com/documentation/metal/mtlblitpasssamplebufferattachmentdescriptor>
+pub enum MTLBlitPassSampleBufferAttachmentDescriptor {}
+
+foreign_obj_type! {
+    type CType = MTLBlitPassSampleBufferAttachmentDescriptor;
+    pub struct BlitPassSampleBufferAttachmentDescriptor;
+}
+
+impl BlitPassSampleBufferAttachmentDescriptor {
+    pub fn new() -> Self {
+        let class = class!(MTLBlitPassSampleBufferAttachmentDescriptor);
+        unsafe { msg_send![class, new] }
+    }
+}
+
+impl BlitPassSampleBufferAttachmentDescriptorRef {
+    pub fn sample_buffer(&self) -> &CounterSampleBufferRef {
+        unsafe { msg_send![self, sampleBuffer] }
+    }
+
+    pub fn set_sample_buffer(&self, sample_buffer: &CounterSampleBufferRef) {
+        unsafe { msg_send![self, setSampleBuffer: sample_buffer] }
+    }
+
+    pub fn start_of_encoder_sample_index(&self) -> NSUInteger {
+        unsafe { msg_send![self, startOfEncoderSampleIndex] }
+    }
+
+    pub fn set_start_of_encoder_sample_index(&self, start_of_encoder_sample_index: NSUInteger) {
+        unsafe {
+            msg_send![
+                self,
+                setStartOfEncoderSampleIndex: start_of_encoder_sample_index
+            ]
+        }
+    }
+
+    pub fn end_of_encoder_sample_index(&self) -> NSUInteger {
+        unsafe { msg_send![self, endOfEncoderSampleIndex] }
+    }
+
+    pub fn set_end_of_encoder_sample_index(&self, end_of_encoder_sample_index: NSUInteger) {
+        unsafe {
+            msg_send![
+                self,
+                setEndOfEncoderSampleIndex: end_of_encoder_sample_index
+            ]
+        }
+    }
+}

--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -109,8 +109,29 @@ impl CommandBufferRef {
         unsafe { msg_send![self, blitCommandEncoder] }
     }
 
+    pub fn blit_command_encoder_with_descriptor(
+        &self,
+        descriptor: &BlitPassDescriptorRef,
+    ) -> &BlitCommandEncoderRef {
+        unsafe { msg_send![self, blitCommandEncoderWithDescriptor: descriptor] }
+    }
+
     pub fn new_compute_command_encoder(&self) -> &ComputeCommandEncoderRef {
         unsafe { msg_send![self, computeCommandEncoder] }
+    }
+
+    pub fn compute_command_encoder_with_dispatch_type(
+        &self,
+        ty: MTLDispatchType,
+    ) -> &ComputeCommandEncoderRef {
+        unsafe { msg_send![self, computeCommandEncoderWithDispatchType: ty] }
+    }
+
+    pub fn compute_command_encoder_with_descriptor(
+        &self,
+        descriptor: &ComputePassDescriptorRef,
+    ) -> &ComputeCommandEncoderRef {
+        unsafe { msg_send![self, computeCommandEncoderWithDescriptor: descriptor] }
     }
 
     pub fn new_render_command_encoder(
@@ -131,20 +152,6 @@ impl CommandBufferRef {
         &self,
     ) -> &AccelerationStructureCommandEncoderRef {
         unsafe { msg_send![self, accelerationStructureCommandEncoder] }
-    }
-
-    pub fn compute_command_encoder_with_dispatch_type(
-        &self,
-        ty: MTLDispatchType,
-    ) -> &ComputeCommandEncoderRef {
-        unsafe { msg_send![self, computeCommandEncoderWithDispatchType: ty] }
-    }
-
-    pub fn compute_command_encoder_with_descriptor(
-        &self,
-        descriptor: &ComputePassDescriptorRef,
-    ) -> &ComputeCommandEncoderRef {
-        unsafe { msg_send![self, computeCommandEncoderWithDescriptor: descriptor] }
     }
 
     pub fn encode_signal_event(&self, event: &EventRef, new_value: u64) {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -9,6 +9,9 @@ use super::*;
 
 use std::ops::Range;
 
+/// See <https://developer.apple.com/documentation/metal/mtlcounterdontsample>
+pub const COUNTER_DONT_SAMPLE: NSUInteger = NSUInteger::MAX; // #define MTLCounterDontSample ((NSUInteger)-1)
+
 /// See <https://developer.apple.com/documentation/metal/mtlprimitivetype>
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1215,6 +1215,22 @@ impl RenderCommandEncoderRef {
             ]
         }
     }
+
+    /// See: <https://developer.apple.com/documentation/metal/mtlrendercommandencoder/3194379-samplecountersinbuffer>
+    pub fn sample_counters_in_buffer(
+        &self,
+        sample_buffer: &CounterSampleBufferRef,
+        sample_index: NSUInteger,
+        with_barrier: bool,
+    ) {
+        unsafe {
+            msg_send![self,
+                sampleCountersInBuffer: sample_buffer
+                atSampleIndex: sample_index
+                withBarrier: with_barrier
+            ]
+        }
+    }
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlblitcommandencoder/>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,6 +548,7 @@ impl MetalLayerRef {
 
 mod accelerator_structure;
 mod argument;
+mod blitpass;
 mod buffer;
 mod capturedescriptor;
 mod capturemanager;
@@ -578,6 +579,7 @@ mod vertexdescriptor;
 pub use {
     accelerator_structure::*,
     argument::*,
+    blitpass::*,
     buffer::*,
     counters::*,
     computepass::*,


### PR DESCRIPTION
* blit command encoder creation with descriptor
* expose `MTLCounterDontSample`
* add `sample_counters_in_buffer` for render command encoder