### PR TITLE
Fix compiling for 32bit architectures

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -117,7 +117,7 @@ impl TextureDescriptorRef {
             height,
             depth,
         } = size;
-        let count = (width.max(height).max(depth) as f64).log2().ceil() as u64;
+        let count = (width.max(height).max(depth) as f64).log2().ceil() as _;
         self.set_mipmap_level_count(count);
     }
 


### PR DESCRIPTION
A small slip-up that prevents compiling on 32bit architectures (which, admittedly, are rare nowadays).

I haven't tested the examples, there are probably similar mistakes as this one in there.