### PR TITLE
add `colorspace` to `MetalLayer`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,13 @@ readme = "README.md"
 keywords = ["metal", "graphics", "bindings"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-exclude = ["guide/**/*", "examples/texture/**/*", "tests/**/*", "Cargo.lock", "target/**/*"]
+exclude = [
+  "guide/**/*",
+  "examples/texture/**/*",
+  "tests/**/*",
+  "Cargo.lock",
+  "target/**/*",
+]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
@@ -29,6 +35,7 @@ block = "0.1.6"
 foreign-types = "0.5"
 dispatch = { version = "0.2", optional = true }
 paste = "1"
+core-graphics = "0.23.1"
 
 [dependencies.objc]
 version = "0.2.4"
@@ -98,6 +105,4 @@ required-features = ["dispatch"]
 name = "fence"
 
 [workspace]
-members = [
-  "examples/texture",
-]
+members = ["examples/texture"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use std::{
     os::raw::c_void,
 };
 
+use core_graphics::color_space::CGColorSpaceRef;
 use core_graphics_types::{base::CGFloat, geometry::CGSize};
 use foreign_types::ForeignType;
 use objc::runtime::{Object, NO, YES};
@@ -543,6 +544,14 @@ impl MetalLayerRef {
                 setWantsExtendedDynamicRangeContent: wants_extended_dynamic_range_content
             ]
         }
+    }
+
+    pub fn colorspace(&self) -> Option<&CGColorSpaceRef> {
+        unsafe { msg_send![self, colorspace] }
+    }
+
+    pub fn set_colorspace(&self, colorspace: Option<&CGColorSpaceRef>) {
+        unsafe { msg_send![self, setColorspace: colorspace] }
     }
 }
 


### PR DESCRIPTION
Add methods to get and set `colorspace`. `core-graphics = "0.23.1"` is introduced.

https://developer.apple.com/documentation/quartzcore/cametallayer/1478170-colorspace?language=objc