### PR TITLE
Remove unused `objc_exception` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ paste = "1"
 
 [dependencies.objc]
 version = "0.2.4"
-features = ["objc_exception"]
 
 [dev-dependencies]
 cocoa = "0.24.0"

--- a/README.md
+++ b/README.md
@@ -8,13 +8,6 @@
 
 <p align="center">Unsafe Rust bindings for the Metal 3D Graphics API.</p>
 
-## Documentation
-
-Note that [docs.rs](docs.rs) will fail to build the (albeit limited) documentation for this crate!
-They build in a Linux container, but of course this will only compile on MacOS.
-
-Please build the documentation yourself with `cargo docs`.
-
 ## Examples
 
 The [examples](/examples) directory highlights different ways of using the Metal graphics API for rendering

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -8,6 +8,7 @@
 use super::*;
 use block::{Block, RcBlock};
 use std::mem;
+use std::ptr;
 
 #[cfg(feature = "dispatch_queue")]
 use dispatch;
@@ -63,7 +64,7 @@ impl SharedEventRef {
                 *mut BlockBase<(&SharedEventRef, u64), ()>,
             >(block);
             (*block).flags |= BLOCK_HAS_SIGNATURE | BLOCK_HAS_COPY_DISPOSE;
-            (*block).extra = &BLOCK_EXTRA;
+            (*block).extra = ptr::addr_of!(BLOCK_EXTRA);
             let () = msg_send![self, notifyListener:listener atValue:value block:block];
         }
 


### PR DESCRIPTION
This one unused `objc_exception` dependency is preventing docs from building on docs.rs, because `cc` tries to pass `-arch`, to GCC, which doesn't see it as a valid argument, when building [`objc-exception`](https://github.com/SSheldon/rust-objc-exception/blob/master/build.rs).

Except, `objc-exception` doesn't really _do anything_ in metal-rs. I grepped for all of the [functions exported by `objc-exception`](https://github.com/SSheldon/rust-objc-exception/blob/master/src/lib.rs), and found nothing at all. I then ran 

* `cargo check --target=x86_64-apple-darwin`
* `cargo check --target=aarch64-apple-ios`
* `cargo check --target=aarch64-apple-darwin`

On both Windows and Linux and it passed with flying colours. To be sure, I checked the source of the [`objc` crate](https://github.com/SSheldon/rust-objc/blob/master/src/lib.rs) crate, where the `exception` feature only brings in `objc-exception` and this [`catch_exception`](https://github.com/SSheldon/rust-objc/blob/master/src/exception.rs#L6) function. There are no special linkage parameters that `objc_exception` provides nor is it used at all by metal-rs and thus wgpu. 

There's no reason to keep this around especially because its the only reason docs are breaking for it. It's causing trouble for downstream consumers of libraries that use wgpu, I've had to resort to workarounds like `#[cfg(all(target_vendor = "apple", feature = "docsrs"))]` to remove wgpu dependencies on my macOS docs build chain.

This should fix https://github.com/gfx-rs/wgpu/issues/2956, https://github.com/gfx-rs/metal-rs/issues/5 , and obviate https://github.com/gfx-rs/metal-rs/pull/250

I've also fixed a `static_mut_ref` warning that cargo was complaining about.