### PR TITLE
Don't re-export `bitflags` and `log`.

### DIFF
--- a/src/accelerator_structure.rs
+++ b/src/accelerator_structure.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLAccelerationStructureInstanceOptions: u32 {
         const None = 0;

--- a/src/device.rs
+++ b/src/device.rs
@@ -8,6 +8,7 @@
 use super::*;
 
 use block::Block;
+use log::warn;
 use objc::runtime::{NO, YES};
 
 use std::{ffi::CStr, os::raw::c_char, path::Path, ptr};
@@ -92,7 +93,7 @@ pub enum MTLDeviceLocation {
     Unspecified = u64::MAX,
 }
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct PixelFormatCapabilities: u32 {
         const Filter = 1 << 0;
@@ -1430,7 +1431,7 @@ pub enum MTLSparseTextureRegionAlignmentMode {
     Inward = 1,
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// Options that determine how Metal prepares the pipeline.
     #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLPipelineOption: NSUInteger {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -74,7 +74,7 @@ pub enum MTLTriangleFillMode {
     Lines = 1,
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// https://developer.apple.com/documentation/metal/mtlblitoption
     #[allow(non_upper_case_globals)]
     #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/indirect_encoder.rs
+++ b/src/indirect_encoder.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-bitflags! {
+bitflags::bitflags! {
     /// See <https://developer.apple.com/documentation/metal/mtlindirectcommandtype/>
     #[allow(non_upper_case_globals)]
     #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,6 @@
 #![allow(non_upper_case_globals)]
 
 #[macro_use]
-pub extern crate bitflags;
-#[macro_use]
-pub extern crate log;
-#[macro_use]
 pub extern crate objc;
 #[macro_use]
 pub extern crate foreign_types;

--- a/src/library.rs
+++ b/src/library.rs
@@ -148,7 +148,7 @@ impl FunctionConstantRef {
     }
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// Only available on (macos(11.0), ios(14.0))
     ///
     /// See <https://developer.apple.com/documentation/metal/mtlfunctionoptions/>

--- a/src/mps.rs
+++ b/src/mps.rs
@@ -40,7 +40,7 @@ pub enum MPSRayDataType {
     OriginMaskDirectionMaxDistance = 2,
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsraymaskoptions>
     #[allow(non_upper_case_globals)]
     #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -116,7 +116,7 @@ pub enum MPSAccelerationStructureStatus {
     Built = 1,
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpsaccelerationstructureusage>
     #[allow(non_upper_case_globals)]
     #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -47,7 +47,7 @@ pub enum MTLBlendOperation {
     Max = 4,
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// See <https://developer.apple.com/documentation/metal/mtlcolorwritemask>
     #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLColorWriteMask: NSUInteger {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -55,7 +55,7 @@ pub const MTLResourceStorageModeMask: NSUInteger = 0xf << MTLResourceStorageMode
 pub const MTLResourceHazardTrackingModeShift: NSUInteger = 8;
 pub const MTLResourceHazardTrackingModeMask: NSUInteger = 0x3 << MTLResourceHazardTrackingModeShift;
 
-bitflags! {
+bitflags::bitflags! {
     /// See <https://developer.apple.com/documentation/metal/mtlresourceoptions>
     #[allow(non_upper_case_globals)]
     #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -77,7 +77,7 @@ bitflags! {
     }
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// Options that describe how a graphics or compute function uses an argument buffer’s resource.
     ///
     /// Enabling certain options for certain resources determines whether the Metal driver should

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -136,7 +136,7 @@ impl FenceRef {
     }
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// The render stages at which a synchronization command is triggered.
     ///
     /// Render stages provide finer control for specifying when synchronization must occur,

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -33,7 +33,7 @@ pub enum MTLTextureCompressionType {
     Lossy = 1,
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// See <https://developer.apple.com/documentation/metal/mtltextureusage>
     #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MTLTextureUsage: NSUInteger {


### PR DESCRIPTION
Also, switch away from `#[macro_use]` and `extern crate` for these crates.