### PR TITLE
Implement creating acceleration structures on a `Heap`

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -2049,6 +2049,13 @@ impl DeviceRef {
         unsafe { msg_send![self, heapBufferSizeAndAlignWithLength: length options: options] }
     }
 
+    pub fn heap_acceleration_structure_size_and_align_with_size(
+        &self,
+        size: NSUInteger,
+    ) -> MTLSizeAndAlign {
+        unsafe { msg_send![self, heapAccelerationStructureSizeAndAlignWithSize: size] }
+    }
+
     pub fn heap_texture_size_and_align(
         &self,
         descriptor: &TextureDescriptorRef,

--- a/src/device.rs
+++ b/src/device.rs
@@ -2049,6 +2049,7 @@ impl DeviceRef {
         unsafe { msg_send![self, heapBufferSizeAndAlignWithLength: length options: options] }
     }
 
+    /// Only available on macos(13.0), ios(16.0)
     pub fn heap_acceleration_structure_size_and_align_with_size(
         &self,
         size: NSUInteger,

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -148,6 +148,69 @@ impl HeapRef {
             }
         }
     }
+
+    /// Only available on macOS 13.0+ & iOS 16.0+
+    pub fn new_acceleration_structure_with_descriptor(
+        &self,
+        descriptor: &AccelerationStructureDescriptorRef,
+    ) -> Option<AccelerationStructure> {
+        unsafe {
+            let ptr: *mut MTLAccelerationStructure =
+                msg_send![self, newAccelerationStructureWithDescriptor: descriptor];
+            if !ptr.is_null() {
+                Some(AccelerationStructure::from_ptr(ptr))
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Only available on macOS 13.0+ & iOS 16.0+
+    pub fn new_acceleration_structure_with_descriptor_offset(
+        &self,
+        descriptor: &AccelerationStructureDescriptorRef,
+        offset: u64,
+    ) -> Option<AccelerationStructure> {
+        unsafe {
+            let ptr: *mut MTLAccelerationStructure = msg_send![self, newAccelerationStructureWithDescriptor:descriptor
+                                                                     offset:offset];
+            if !ptr.is_null() {
+                Some(AccelerationStructure::from_ptr(ptr))
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Only available on macOS 13.0+ & iOS 16.0+
+    pub fn new_acceleration_structure_with_size(&self, size: u64) -> Option<AccelerationStructure> {
+        unsafe {
+            let ptr: *mut MTLAccelerationStructure =
+                msg_send![self, newAccelerationStructureWithSize:size];
+            if !ptr.is_null() {
+                Some(AccelerationStructure::from_ptr(ptr))
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Only available on macOS 13.0+ & iOS 16.0+
+    pub fn new_acceleration_structure_with_size_offset(
+        &self,
+        size: u64,
+        offset: u64,
+    ) -> Option<AccelerationStructure> {
+        unsafe {
+            let ptr: *mut MTLAccelerationStructure = msg_send![self, newAccelerationStructureWithSize:size
+                                                                     offset:offset];
+            if !ptr.is_null() {
+                Some(AccelerationStructure::from_ptr(ptr))
+            } else {
+                None
+            }
+        }
+    }
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlheapdescriptor/>

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -260,6 +260,10 @@ impl HeapDescriptorRef {
         unsafe { msg_send![self, hazardTrackingMode] }
     }
 
+    pub fn set_hazard_tracking_mode(&self, hazard_tracking_mode: MTLHazardTrackingMode) {
+        unsafe { msg_send![self, setHazardTrackingMode: hazard_tracking_mode] }
+    }
+
     /// Only available on macos(10.15), ios(13.0)
     pub fn resource_options(&self) -> MTLResourceOptions {
         unsafe { msg_send![self, resourceOptions] }
@@ -268,5 +272,9 @@ impl HeapDescriptorRef {
     /// Only available on macos(10.15), ios(13.0)
     pub fn heap_type(&self) -> MTLHeapType {
         unsafe { msg_send![self, type] }
+    }
+
+    pub fn set_heap_type(&self, type_: MTLHeapType) {
+        unsafe { msg_send![self, setType: type_] }
     }
 }

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -260,6 +260,7 @@ impl HeapDescriptorRef {
         unsafe { msg_send![self, hazardTrackingMode] }
     }
 
+    /// Only available on macos(10.15), ios(13.0)
     pub fn set_hazard_tracking_mode(&self, hazard_tracking_mode: MTLHazardTrackingMode) {
         unsafe { msg_send![self, setHazardTrackingMode: hazard_tracking_mode] }
     }
@@ -273,7 +274,7 @@ impl HeapDescriptorRef {
     pub fn heap_type(&self) -> MTLHeapType {
         unsafe { msg_send![self, type] }
     }
-
+    /// Only available on macos(10.15), ios(13.0)
     pub fn set_heap_type(&self, type_: MTLHeapType) {
         unsafe { msg_send![self, setType: type_] }
     }


### PR DESCRIPTION
Implements allocating acceleration structures from a heap using the `newAccelerationStructureWithDescriptor` and `newAccelerationStructureWithSize` functions, as well as `heapAccelerationStructureSizeAndAlignWithSize` on Device. Additionally implements two missing functions `setHazardTrackingMode` and `setType`.