### PR TITLE
Fix accelerator structure `descriptor` methods

### DIFF
--- a/src/accelerator_structure.rs
+++ b/src/accelerator_structure.rs
@@ -81,7 +81,9 @@ impl PrimitiveAccelerationStructureDescriptor {
     pub fn descriptor() -> Self {
         unsafe {
             let class = class!(MTLPrimitiveAccelerationStructureDescriptor);
-            msg_send![class, descriptor]
+            let ptr: *mut Object = msg_send![class, descriptor];
+            let ptr: *mut Object = msg_send![ptr, retain];
+            Self::from_ptr(ptr as _)
         }
     }
 }
@@ -150,7 +152,9 @@ impl AccelerationStructureTriangleGeometryDescriptor {
     pub fn descriptor() -> Self {
         unsafe {
             let class = class!(MTLAccelerationStructureTriangleGeometryDescriptor);
-            msg_send![class, descriptor]
+            let ptr: *mut Object = msg_send![class, descriptor];
+            let ptr: *mut Object = msg_send![ptr, retain];
+            Self::from_ptr(ptr as _)
         }
     }
 }
@@ -209,7 +213,9 @@ impl AccelerationStructureBoundingBoxGeometryDescriptor {
     pub fn descriptor() -> Self {
         unsafe {
             let class = class!(MTLAccelerationStructureBoundingBoxGeometryDescriptor);
-            msg_send![class, descriptor]
+            let ptr: *mut Object = msg_send![class, descriptor];
+            let ptr: *mut Object = msg_send![ptr, retain];
+            Self::from_ptr(ptr as _)
         }
     }
 }
@@ -236,7 +242,9 @@ impl InstanceAccelerationStructureDescriptor {
     pub fn descriptor() -> Self {
         unsafe {
             let class = class!(MTLInstanceAccelerationStructureDescriptor);
-            msg_send![class, descriptor]
+            let ptr: *mut Object = msg_send![class, descriptor];
+            let ptr: *mut Object = msg_send![ptr, retain];
+            Self::from_ptr(ptr as _)
         }
     }
 }
@@ -282,7 +290,9 @@ impl IndirectInstanceAccelerationStructureDescriptor {
     pub fn descriptor() -> Self {
         unsafe {
             let class = class!(MTLIndirectInstanceAccelerationStructureDescriptor);
-            msg_send![class, descriptor]
+            let ptr: *mut Object = msg_send![class, descriptor];
+            let ptr: *mut Object = msg_send![ptr, retain];
+            Self::from_ptr(ptr as _)
         }
     }
 }


### PR DESCRIPTION
These return a +0 autoreleased pointer, so we have to retain them ourselves before we put them in the strong smart pointer created by `foreign_obj_type!`.

Fixes https://github.com/gfx-rs/metal-rs/issues/319.