### PR TITLE
Use correct feature name for `dispatch`

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -9,7 +9,7 @@ use super::*;
 use block::{Block, RcBlock};
 use std::ptr;
 
-#[cfg(feature = "dispatch_queue")]
+#[cfg(feature = "dispatch")]
 use dispatch;
 
 /// See <https://developer.apple.com/documentation/metal/mtlsharedeventnotificationblock>


### PR DESCRIPTION
The feature used to be called `dispatch-queue` but was renamed to `dispatch`, so this updates the module to match