### PR TITLE
Correct `refit_acceleration_structure` destination parameter

### DIFF
--- a/src/accelerator_structure.rs
+++ b/src/accelerator_structure.rs
@@ -448,7 +448,7 @@ impl AccelerationStructureCommandEncoderRef {
         &self,
         source_acceleration_structure: &AccelerationStructureRef,
         descriptor: &self::AccelerationStructureDescriptorRef,
-        destination_acceleration_structure: &AccelerationStructureRef,
+        destination_acceleration_structure: Option<&AccelerationStructureRef>,
         scratch_buffer: &BufferRef,
         scratch_buffer_offset: NSUInteger,
     ) {


### PR DESCRIPTION
According to [the Metal documentation for `refitAccelerationStructure`](https://developer.apple.com/documentation/metal/mtlaccelerationstructurecommandencoder/3553898-refitaccelerationstructure?language=objc), we can pass nil to `destinationAccelerationStructure`, which will then refit the acceleration structure in-place. This PR turns the parameter into an `Option<_>`, so the user can pass `None` to refit in place.