### PR TITLE
Add `gpu_start_time` and `gpu_end_time` to `CommandBuffer`

### DIFF
--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -66,6 +66,14 @@ impl CommandBufferRef {
         }
     }
 
+    pub fn gpu_start_time(&self) -> f64 {
+        unsafe { msg_send![self, GPUStartTime] }
+    }
+
+    pub fn gpu_end_time(&self) -> f64 {
+        unsafe { msg_send![self, GPUEndTime] }
+    }
+
     pub fn set_label(&self, label: &str) {
         unsafe {
             let nslabel = crate::nsstring_from_str(label);


### PR DESCRIPTION
Add bindings for [`GPUStartTime`](https://developer.apple.com/documentation/metal/mtlcommandbuffer/1639924-gpustarttime?language=objc) and [`GPUEndTime`](https://developer.apple.com/documentation/metal/mtlcommandbuffer/1639926-gpuendtime?language=objc). 

They allow you to determine how much time the GPU spent executing a command buffer. 