### PR TITLE
Disable default `link` feature on `core-graphics-types`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ mps = []
 link = ["core-graphics-types/link"]
 
 [dependencies]
-core-graphics-types = "0.1.3"
+core-graphics-types = { version = "0.1.3", default-features = false }
 bitflags = "2"
 log = "0.4"
 block = "0.1.6"


### PR DESCRIPTION
When the `link` feature was forwarded to `core-graphics-types` in its update in https://github.com/gfx-rs/metal-rs/pull/297, it wasn't taken into account that  the feature was enabled by default in https://togithub.com/servo/core-foundation-rs/pull/608, leading to the `link` feature to always remain enabled even if `default-features` are **disabled** on the `metal` crate.

Disable the `link` feature by default on `core-graphics-types`, and rely on our (default-enabled) `link` feature to turn it back on from inside `metal`.