### PR TITLE
Remove dev-dependency `cty`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ version = "0.2.4"
 
 [dev-dependencies]
 cocoa = "0.25.0"
-cty = "0.2.1"
 winit = "0.29"
 sema = "0.1.4"
 png = "0.17"

--- a/examples/circle/main.rs
+++ b/examples/circle/main.rs
@@ -20,10 +20,10 @@ use std::mem;
 // based on C++
 #[repr(C)]
 #[derive(Debug)]
-pub struct position(cty::c_float, cty::c_float);
+pub struct position(std::ffi::c_float, std::ffi::c_float);
 #[repr(C)]
 #[derive(Debug)]
-pub struct color(cty::c_float, cty::c_float, cty::c_float);
+pub struct color(std::ffi::c_float, std::ffi::c_float, std::ffi::c_float);
 #[repr(C)]
 #[derive(Debug)]
 pub struct AAPLVertex {


### PR DESCRIPTION
This can be replaced with using `std::ffi` instead. This was added in Rust 1.64, but doesn't impact our MSRV as the examples use winit and glam, which have MSRVS of 1.65 and 1.68.2 respectively for the versions used at the time of this commit.