### PR TITLE
Set and test MSRV at 1.82

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
 
     strategy:
       matrix:
-        channel: [stable, nightly]
+        channel: [1.82, stable, nightly]
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Setup rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.channel }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = [
   "Cargo.lock",
   "target/**/*",
 ]
+rust-version = "1.82"
 
 [package.metadata.docs.rs]
 targets = [

--- a/examples/circle/main.rs
+++ b/examples/circle/main.rs
@@ -52,7 +52,7 @@ fn main() {
     device.sample_timestamps(&mut cpu_start, &mut gpu_start);
     let counter_sample_buffer = create_counter_sample_buffer(&device);
     let destination_buffer = device.new_buffer(
-        (std::mem::size_of::<u64>() * 4 as usize) as u64,
+        (size_of::<u64>() * 4 as usize) as u64,
         MTLResourceOptions::StorageModeShared,
     );
     let counter_sampling_point = MTLCounterSamplingPoint::AtStageBoundary;
@@ -116,7 +116,7 @@ fn main() {
 
         device.new_buffer_with_data(
             vertex_data.as_ptr() as *const _,
-            (vertex_data.len() * mem::size_of::<AAPLVertex>()) as u64,
+            (vertex_data.len() * size_of::<AAPLVertex>()) as u64,
             MTLResourceOptions::CPUCacheModeDefaultCache | MTLResourceOptions::StorageModeManaged,
         )
     };

--- a/examples/compute/compute-argument-buffer.rs
+++ b/examples/compute/compute-argument-buffer.rs
@@ -23,7 +23,7 @@ fn main() {
 
         let buffer = device.new_buffer_with_data(
             unsafe { mem::transmute(data.as_ptr()) },
-            (data.len() * mem::size_of::<u32>()) as u64,
+            (data.len() * size_of::<u32>()) as u64,
             MTLResourceOptions::CPUCacheModeDefaultCache,
         );
 
@@ -31,7 +31,7 @@ fn main() {
             let data = [0u32];
             device.new_buffer_with_data(
                 unsafe { mem::transmute(data.as_ptr()) },
-                (data.len() * mem::size_of::<u32>()) as u64,
+                (data.len() * size_of::<u32>()) as u64,
                 MTLResourceOptions::CPUCacheModeDefaultCache,
             )
         };

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -18,7 +18,7 @@ fn main() {
 
         let counter_sample_buffer = create_counter_sample_buffer(&device);
         let destination_buffer = device.new_buffer(
-            (std::mem::size_of::<u64>() * NUM_SAMPLES as usize) as u64,
+            (size_of::<u64>() * NUM_SAMPLES as usize) as u64,
             MTLResourceOptions::StorageModeShared,
         );
 
@@ -171,7 +171,7 @@ fn create_input_and_output_buffers(
 
     let buffer = device.new_buffer_with_data(
         unsafe { std::mem::transmute(data.as_ptr()) },
-        (data.len() * std::mem::size_of::<u32>()) as u64,
+        (data.len() * size_of::<u32>()) as u64,
         MTLResourceOptions::CPUCacheModeDefaultCache,
     );
 
@@ -179,7 +179,7 @@ fn create_input_and_output_buffers(
         let data = [0u32];
         device.new_buffer_with_data(
             unsafe { std::mem::transmute(data.as_ptr()) },
-            (data.len() * std::mem::size_of::<u32>()) as u64,
+            (data.len() * size_of::<u32>()) as u64,
             MTLResourceOptions::CPUCacheModeDefaultCache,
         )
     };

--- a/examples/headless-render/main.rs
+++ b/examples/headless-render/main.rs
@@ -1,4 +1,3 @@
-use std::mem;
 use std::path::PathBuf;
 
 use std::fs::File;
@@ -144,7 +143,7 @@ fn prepare_pipeline_state(device: &DeviceRef, library: &LibraryRef) -> RenderPip
 fn create_vertex_buffer(device: &DeviceRef) -> Buffer {
     device.new_buffer_with_data(
         VERTEX_ATTRIBS.as_ptr() as *const _,
-        (VERTEX_ATTRIBS.len() * mem::size_of::<f32>()) as u64,
+        (VERTEX_ATTRIBS.len() * size_of::<f32>()) as u64,
         MTLResourceOptions::CPUCacheModeDefaultCache | MTLResourceOptions::StorageModeManaged,
     )
 }

--- a/examples/mps/main.rs
+++ b/examples/mps/main.rs
@@ -1,6 +1,5 @@
 use metal::*;
 use std::ffi::c_void;
-use std::mem;
 
 #[repr(C)]
 struct Vertex {
@@ -39,7 +38,7 @@ fn main() {
         },
     ];
 
-    let vertex_stride = mem::size_of::<Vertex>();
+    let vertex_stride = size_of::<Vertex>();
 
     let indices: [u32; 3] = [0, 1, 2];
 
@@ -56,7 +55,7 @@ fn main() {
 
     let index_buffer = device.new_buffer_with_data(
         indices.as_ptr() as *const c_void,
-        (mem::size_of::<u32>() * indices.len()) as u64,
+        (size_of::<u32>() * indices.len()) as u64,
         buffer_opts,
     );
 
@@ -75,9 +74,9 @@ fn main() {
     let ray_intersector =
         mps::RayIntersector::from_device(&device).expect("Failed to create ray intersector");
 
-    ray_intersector.set_ray_stride(mem::size_of::<Ray>() as u64);
+    ray_intersector.set_ray_stride(size_of::<Ray>() as u64);
     ray_intersector.set_ray_data_type(mps::MPSRayDataType::OriginMinDistanceDirectionMaxDistance);
-    ray_intersector.set_intersection_stride(mem::size_of::<Intersection>() as u64);
+    ray_intersector.set_intersection_stride(size_of::<Intersection>() as u64);
     ray_intersector.set_intersection_data_type(
         mps::MPSIntersectionDataType::DistancePrimitiveIndexCoordinates,
     );
@@ -85,12 +84,12 @@ fn main() {
     // Create a buffer to hold generated rays and intersection results
     let ray_count = 1024;
     let ray_buffer = device.new_buffer(
-        (mem::size_of::<Ray>() * ray_count) as u64,
+        (size_of::<Ray>() * ray_count) as u64,
         MTLResourceOptions::StorageModePrivate,
     );
 
     let intersection_buffer = device.new_buffer(
-        (mem::size_of::<Intersection>() * ray_count) as u64,
+        (size_of::<Intersection>() * ray_count) as u64,
         MTLResourceOptions::StorageModePrivate,
     );
 

--- a/examples/raytracing/geometry.rs
+++ b/examples/raytracing/geometry.rs
@@ -1,7 +1,4 @@
-use std::{
-    mem::{size_of, transmute},
-    sync::Arc,
-};
+use std::{mem::transmute, sync::Arc};
 
 use glam::{
     f32::{Mat4, Vec3, Vec4},

--- a/examples/raytracing/renderer.rs
+++ b/examples/raytracing/renderer.rs
@@ -2,7 +2,7 @@ use core_graphics_types::{base::CGFloat, geometry::CGSize};
 use std::{
     collections::BTreeMap,
     ffi::c_void,
-    mem::{size_of, transmute},
+    mem::transmute,
     ops::Index,
     sync::{Arc, Condvar, Mutex},
 };
@@ -475,21 +475,13 @@ impl Renderer {
         let constants = FunctionConstantValues::new();
         let resources_stride = resources_stride * size_of::<u64>() as u32;
         constants.set_constant_value_at_index(
-            &resources_stride as *const u32 as *const c_void,
+            &raw const resources_stride as *const c_void,
             MTLDataType::UInt,
             0,
         );
         let v = true;
-        constants.set_constant_value_at_index(
-            &v as *const bool as *const c_void,
-            MTLDataType::Bool,
-            1,
-        );
-        constants.set_constant_value_at_index(
-            &v as *const bool as *const c_void,
-            MTLDataType::Bool,
-            2,
-        );
+        constants.set_constant_value_at_index(&raw const v as *const c_void, MTLDataType::Bool, 1);
+        constants.set_constant_value_at_index(&raw const v as *const c_void, MTLDataType::Bool, 2);
         library.get_function(name, Some(constants)).unwrap()
     }
 

--- a/examples/raytracing/scene.rs
+++ b/examples/raytracing/scene.rs
@@ -1,4 +1,4 @@
-use std::{ffi::c_void, mem::size_of, sync::Arc};
+use std::{ffi::c_void, sync::Arc};
 
 use glam::{Mat4, Vec3, Vec4};
 use rand::{thread_rng, Rng};

--- a/examples/texture/src/main.rs
+++ b/examples/texture/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
     let vertex_data = vertices();
     let vertex_buffer = device.new_buffer_with_data(
         vertex_data.as_ptr() as *const _,
-        (vertex_data.len() * std::mem::size_of::<TexturedVertex>()) as u64,
+        (vertex_data.len() * size_of::<TexturedVertex>()) as u64,
         MTLResourceOptions::CPUCacheModeDefaultCache | MTLResourceOptions::StorageModeManaged,
     );
 
@@ -225,7 +225,7 @@ fn prepare_pipeline_state(device: &Device, library: &Library) -> RenderPipelineS
 fn update_viewport_size_buffer(viewport_size_buffer: &Buffer, size: (u32, u32)) {
     let contents = viewport_size_buffer.contents();
     let viewport_size: [u32; 2] = [size.0, size.1];
-    let byte_count = (viewport_size.len() * std::mem::size_of::<u32>()) as usize;
+    let byte_count = (viewport_size.len() * size_of::<u32>()) as usize;
 
     unsafe {
         std::ptr::copy(viewport_size.as_ptr(), contents as *mut u32, byte_count);

--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -135,7 +135,7 @@ fn main() {
 
         device.new_buffer_with_data(
             vertex_data.as_ptr() as *const _,
-            (vertex_data.len() * mem::size_of::<f32>()) as u64,
+            (vertex_data.len() * size_of::<f32>()) as u64,
             MTLResourceOptions::CPUCacheModeDefaultCache | MTLResourceOptions::StorageModeManaged,
         )
     };
@@ -159,7 +159,7 @@ fn main() {
 
     let clear_rect_buffer = device.new_buffer_with_data(
         clear_rect.as_ptr() as *const _,
-        mem::size_of::<ClearRect>() as u64,
+        size_of::<ClearRect>() as u64,
         MTLResourceOptions::CPUCacheModeDefaultCache | MTLResourceOptions::StorageModeManaged,
     );
 
@@ -202,13 +202,13 @@ fn main() {
                                 std::ptr::copy(
                                     vertex_data.as_ptr(),
                                     p as *mut f32,
-                                    (vertex_data.len() * mem::size_of::<f32>()) as usize,
+                                    (vertex_data.len() * size_of::<f32>()) as usize,
                                 );
                             }
 
                             vbuf.did_modify_range(crate::NSRange::new(
                                 0 as u64,
-                                (vertex_data.len() * mem::size_of::<f32>()) as u64,
+                                (vertex_data.len() * size_of::<f32>()) as u64,
                             ));
 
                             let drawable = match layer.next_drawable() {

--- a/src/counters.rs
+++ b/src/counters.rs
@@ -1,5 +1,4 @@
 use crate::{MTLStorageMode, NSUInteger};
-use std::mem;
 
 /// See <https://developer.apple.com/documentation/metal/mtlcountersamplebufferdescriptor>
 pub enum MTLCounterSampleBufferDescriptor {}
@@ -71,7 +70,7 @@ impl CounterSampleBufferRef {
 
     pub fn resolve_counter_range(&self, range: crate::NSRange) -> Vec<NSUInteger> {
         let mut data = vec![0 as NSUInteger; range.length as usize];
-        let total_bytes = range.length * mem::size_of::<NSUInteger>() as u64;
+        let total_bytes = range.length * size_of::<NSUInteger>() as u64;
         unsafe {
             let ns_data: *mut crate::Object = msg_send![self, resolveCounterRange: range];
             let () = msg_send![ns_data, getBytes: data.as_mut_ptr() length: total_bytes];

--- a/src/device.rs
+++ b/src/device.rs
@@ -11,12 +11,7 @@ use block::Block;
 use log::warn;
 use objc::runtime::{NO, YES};
 
-use std::{
-    ffi::CStr,
-    os::raw::c_char,
-    path::Path,
-    ptr::{self, addr_of_mut},
-};
+use std::{ffi::CStr, os::raw::c_char, path::Path, ptr};
 
 /// Available on macOS 10.11+, iOS 8.0+, tvOS 9.0+
 ///
@@ -1730,7 +1725,7 @@ impl DeviceRef {
             let data = dispatch_data_create(
                 library_data.as_ptr() as *const std::ffi::c_void,
                 library_data.len() as crate::c_size_t,
-                addr_of_mut!(_dispatch_main_q),
+                &raw mut _dispatch_main_q,
                 DISPATCH_DATA_DESTRUCTOR_DEFAULT,
             );
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -5,9 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::ffi::CStr;
+
 use super::*;
 use block::{Block, RcBlock};
-use std::ptr;
 
 #[cfg(feature = "dispatch")]
 use dispatch;
@@ -63,14 +64,14 @@ impl SharedEventRef {
                 *mut BlockBase<(&SharedEventRef, u64), ()>,
             >(block);
             (*block).flags |= BLOCK_HAS_SIGNATURE | BLOCK_HAS_COPY_DISPOSE;
-            (*block).extra = ptr::addr_of!(BLOCK_EXTRA);
+            (*block).extra = &raw const BLOCK_EXTRA;
             let () = msg_send![self, notifyListener:listener atValue:value block:block];
         }
 
         extern "C" fn dtor(_: *mut BlockBase<(&SharedEventRef, u64), ()>) {}
 
-        const SIGNATURE: &[u8] = b"v16@?0Q8\0";
-        const SIGNATURE_PTR: *const i8 = &SIGNATURE[0] as *const u8 as *const i8;
+        const SIGNATURE: &CStr = c"v16@?0Q8";
+        const SIGNATURE_PTR: *const i8 = SIGNATURE.as_ptr().cast();
         static mut BLOCK_EXTRA: BlockExtra<(&SharedEventRef, u64), ()> = BlockExtra {
             unknown0: 0 as *mut i32,
             unknown1: 0 as *mut i32,


### PR DESCRIPTION
Following https://github.com/gfx-rs/metal-rs/pull/343#issuecomment-2708428426

This also makes use of `size_of(_val)()` being imporced via the prelude, `&raw` pointers being available to - for example - save on casts from borrows to raw pointers, and C-string literals automatically appending NUL terminators to strings.