### PR TITLE
examples: Replace one more `unsafe transmute()` with trivial `ptr::cast()`

### DIFF
--- a/examples/compute/compute-argument-buffer.rs
+++ b/examples/compute/compute-argument-buffer.rs
@@ -87,7 +87,7 @@ fn main() {
         command_buffer.commit();
         command_buffer.wait_until_completed();
 
-        let sum = unsafe { sum.contents().cast::<u32>().read() };
+        let sum = unsafe { *sum.contents().cast::<u32>() };
         assert_eq!(465, sum);
     });
 }

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -69,7 +69,7 @@ fn main() {
         let mut gpu_end = 0;
         device.sample_timestamps(&mut cpu_end, &mut gpu_end);
 
-        let sum = unsafe { sum.contents().cast::<u32>().read() };
+        let sum = unsafe { *sum.contents().cast::<u32>() };
         println!("Compute shader sum: {}", sum);
 
         assert_eq!(num_elements, sum);

--- a/examples/raytracing/renderer.rs
+++ b/examples/raytracing/renderer.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::BTreeMap,
-    mem::transmute,
     ops::Index,
     sync::{Arc, Condvar, Mutex},
 };
@@ -451,10 +450,9 @@ impl Renderer {
         command_encoder.end_encoding();
         command_buffer.commit();
         command_buffer.wait_until_completed();
-        let compacted_size: *const u32 = unsafe { transmute(compacted_size_buffer.contents()) };
-        let compacted_size = unsafe { *compacted_size } as NSUInteger;
+        let compacted_size = unsafe { *compacted_size_buffer.contents().cast::<u32>() };
         let compacted_acceleration_structure =
-            device.new_acceleration_structure_with_size(compacted_size);
+            device.new_acceleration_structure_with_size(compacted_size as NSUInteger);
         let command_buffer = queue.new_command_buffer();
         let command_encoder = command_buffer.new_acceleration_structure_command_encoder();
         command_encoder.copy_and_compact_acceleration_structure(


### PR DESCRIPTION
Noticed that one more pointer was being transmuted to another type rather than using a trivial cast, before `unsafe`ly dereferencing it.

This also removes the `ptr::read()` syntax introduced in #344 again, in favour of using a simple and more standard `*` deref.