### PR TITLE
chore(.gitignore): ignore `**/*.air.tmp`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Cargo.lock
 .idea
 
 **/*.air
+**/*.air.tmp


### PR DESCRIPTION
These files can be generated while compiling Metal shaders via `build.rs`, so ignore them, too.