### PR TITLE
Provide gpu_resource_id for Metal Buffers

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -68,4 +68,8 @@ impl BufferRef {
     pub fn gpu_address(&self) -> u64 {
         unsafe { msg_send![self, gpuAddress] }
     }
+
+    pub fn gpu_resource_id(&self) -> MTLResourceID {
+        unsafe { msg_send![self, gpuResourceID] }
+    }
 }


### PR DESCRIPTION
This mirrors what's available for e.g. textures and samplers, and is necessary to support storage buffers in binding arrays on Metal. There will be a corresponding wgpu PR that depends on this one.