### PR TITLE
Fix enum representation for ILP32 platforms (arm64_32)

### DIFF
--- a/src/acceleration_structure.rs
+++ b/src/acceleration_structure.rs
@@ -19,7 +19,7 @@ bitflags::bitflags! {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlaccelerationstructureinstancedescriptortype>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum MTLAccelerationStructureInstanceDescriptorType {

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -9,7 +9,7 @@ use super::{MTLTextureType, NSUInteger};
 use objc::runtime::{NO, YES};
 
 /// See <https://developer.apple.com/documentation/metal/mtldatatype>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLDataType {
@@ -133,7 +133,7 @@ pub enum MTLDataType {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlargumenttype>
-#[repr(u64)]
+#[repr(usize)]
 #[deprecated(
     note = "Since: iOS 8.0–16.0, iPadOS 8.0–16.0, macOS 10.11–13.0, Mac Catalyst 13.1–16.0, tvOS 9.0–16.0"
 )]
@@ -149,7 +149,7 @@ pub enum MTLArgumentType {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlargumentaccess>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLArgumentAccess {

--- a/src/capturedescriptor.rs
+++ b/src/capturedescriptor.rs
@@ -10,7 +10,7 @@ use super::*;
 use std::path::Path;
 
 /// See <https://developer.apple.com/documentation/metal/mtlcapturedestination?language=objc>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLCaptureDestination {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 /// See <https://developer.apple.com/documentation/metal/mtlpixelformat>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum MTLPixelFormat {

--- a/src/depthstencil.rs
+++ b/src/depthstencil.rs
@@ -9,7 +9,7 @@ use crate::DeviceRef;
 use objc::runtime::{NO, YES};
 
 /// See <https://developer.apple.com/documentation/metal/mtlcomparefunction>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLCompareFunction {
     Never = 0,
@@ -23,7 +23,7 @@ pub enum MTLCompareFunction {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlstenciloperation>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLStencilOperation {
     Keep = 0,

--- a/src/device.rs
+++ b/src/device.rs
@@ -24,7 +24,7 @@ use std::{
 #[deprecated(
     note = "Since iOS 8.0–16.0 iPadOS 8.0–16.0 macOS 10.11–13.0 Mac Catalyst 13.1–16.0 tvOS 9.0–16.0"
 )]
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLFeatureSet {
     iOS_GPUFamily1_v1 = 0,
@@ -64,7 +64,7 @@ pub enum MTLFeatureSet {
 /// Available on macOS 10.15+, iOS 13.0+
 ///
 /// See <https://developer.apple.com/documentation/metal/mtlgpufamily>
-#[repr(i64)]
+#[repr(isize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[non_exhaustive]
 pub enum MTLGPUFamily {
@@ -88,13 +88,13 @@ pub enum MTLGPUFamily {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtldevicelocation>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLDeviceLocation {
     BuiltIn = 0,
     Slot = 1,
     External = 2,
-    Unspecified = u64::MAX,
+    Unspecified = usize::MAX,
 }
 
 bitflags::bitflags! {
@@ -1396,7 +1396,7 @@ impl MTLFeatureSet {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlargumentbufferstier>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLArgumentBuffersTier {
     Tier1 = 0,
@@ -1404,7 +1404,7 @@ pub enum MTLArgumentBuffersTier {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlreadwritetexturetier>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLReadWriteTextureTier {
     TierNone = 0,
@@ -1415,7 +1415,7 @@ pub enum MTLReadWriteTextureTier {
 /// Only available on (macos(11.0), ios(14.0))
 ///
 /// See <https://developer.apple.com/documentation/metal/mtlcountersamplingpoint>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLCounterSamplingPoint {
     AtStageBoundary = 0,
@@ -1429,7 +1429,7 @@ pub enum MTLCounterSamplingPoint {
 /// Kinda a long name!
 ///
 /// See <https://developer.apple.com/documentation/metal/mtlsparsetextureregionalignmentmode>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLSparseTextureRegionAlignmentMode {
     Outward = 0,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -13,7 +13,7 @@ use std::ops::Range;
 pub const COUNTER_DONT_SAMPLE: NSUInteger = NSUInteger::MAX; // #define MTLCounterDontSample ((NSUInteger)-1)
 
 /// See <https://developer.apple.com/documentation/metal/mtlprimitivetype>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLPrimitiveType {
     Point = 0,
@@ -24,7 +24,7 @@ pub enum MTLPrimitiveType {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlindextype>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLIndexType {
@@ -33,7 +33,7 @@ pub enum MTLIndexType {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlvisibilityresultmode>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLVisibilityResultMode {
     Disabled = 0,
@@ -42,7 +42,7 @@ pub enum MTLVisibilityResultMode {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlcullmode>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLCullMode {
     None = 0,
@@ -51,7 +51,7 @@ pub enum MTLCullMode {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlwinding>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLWinding {
     Clockwise = 0,
@@ -59,7 +59,7 @@ pub enum MTLWinding {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtldepthclipmode>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLDepthClipMode {
     Clip = 0,
@@ -67,7 +67,7 @@ pub enum MTLDepthClipMode {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtltrianglefillmode>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLTriangleFillMode {
     Fill = 0,

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -10,7 +10,7 @@ use super::*;
 /// Only available on macos(10.15), ios(13.0)
 ///
 /// See <https://developer.apple.com/documentation/metal/mtlheaptype/>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLHeapType {
     Automatic = 0,

--- a/src/library.rs
+++ b/src/library.rs
@@ -15,7 +15,7 @@ use std::ptr;
 /// Only available on (macos(10.12), ios(10.0)
 ///
 /// See <https://developer.apple.com/documentation/metal/mtlpatchtype/>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLPatchType {
     None = 0,
@@ -104,7 +104,7 @@ impl AttributeRef {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlfunctiontype/>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLFunctionType {
     Vertex = 1,
@@ -344,7 +344,7 @@ impl FunctionRef {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtllanguageversion/>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub enum MTLLanguageVersion {
     V1_0 = 0x10000,
@@ -410,7 +410,7 @@ impl FunctionConstantValuesRef {
 /// Only available on (macos(11.0), ios(14.0))
 ///
 /// See <https://developer.apple.com/documentation/metal/mtllibrarytype/>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLLibraryType {
     Executable = 0,
@@ -537,7 +537,7 @@ impl CompileOptionsRef {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtllibraryerror/>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLLibraryError {
     Unsupported = 1,
@@ -679,7 +679,7 @@ impl LibraryRef {
 /// Only available on (macos(11.0), ios(14.0))
 ///
 /// See <https://developer.apple.com/documentation/metal/mtldynamiclibraryerror/>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLDynamicLibraryError {
     None = 0,

--- a/src/mps.rs
+++ b/src/mps.rs
@@ -410,7 +410,7 @@ impl TriangleAccelerationStructureRef {
 }
 
 /// See <https://developer.apple.com/documentation/metalperformanceshaders/mpstransformtype>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MPSTransformType {
     Float4x4 = 0,

--- a/src/pipeline/compute.rs
+++ b/src/pipeline/compute.rs
@@ -10,7 +10,7 @@ use super::*;
 use objc::runtime::{NO, YES};
 
 /// See <https://developer.apple.com/documentation/metal/mtlattributeformat>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLAttributeFormat {
@@ -69,7 +69,7 @@ pub enum MTLAttributeFormat {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlstepfunction>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLStepFunction {

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -14,7 +14,7 @@ pub use self::compute::*;
 pub use self::render::*;
 
 /// See <https://developer.apple.com/documentation/metal/mtlmutability>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLMutability {

--- a/src/pipeline/render.rs
+++ b/src/pipeline/render.rs
@@ -10,7 +10,7 @@ use super::*;
 use objc::runtime::{NO, YES};
 
 /// See <https://developer.apple.com/documentation/metal/mtlblendfactor>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLBlendFactor {
@@ -36,7 +36,7 @@ pub enum MTLBlendFactor {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlblendoperation>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLBlendOperation {
@@ -61,7 +61,7 @@ bitflags::bitflags! {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlprimitivetopologyclass>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLPrimitiveTopologyClass {

--- a/src/renderpass.rs
+++ b/src/renderpass.rs
@@ -8,7 +8,7 @@
 use super::*;
 
 /// See <https://developer.apple.com/documentation/metal/mtlloadaction>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug)]
 pub enum MTLLoadAction {
     DontCare = 0,
@@ -17,7 +17,7 @@ pub enum MTLLoadAction {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlstoreaction>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug)]
 pub enum MTLStoreAction {
     DontCare = 0,

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -9,7 +9,7 @@ use super::*;
 use objc::runtime::{NO, YES};
 
 /// See <https://developer.apple.com/documentation/metal/mtlpurgeablestate>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLPurgeableState {
     KeepCurrent = 1,
@@ -19,7 +19,7 @@ pub enum MTLPurgeableState {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlcpucachemode>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLCPUCacheMode {
     DefaultCache = 0,
@@ -27,7 +27,7 @@ pub enum MTLCPUCacheMode {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlstoragemode>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLStorageMode {
     Shared = 0,
@@ -40,7 +40,7 @@ pub enum MTLStorageMode {
 /// Only available on macos(10.15), ios(13.0)
 ///
 /// See <https://developer.apple.com/documentation/metal/mtlhazardtrackingmode>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum MTLHazardTrackingMode {
     Default = 0,

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -8,7 +8,7 @@
 use super::{depthstencil::MTLCompareFunction, DeviceRef, MTLResourceID, NSUInteger};
 
 /// See <https://developer.apple.com/documentation/metal/mtlsamplerminmagfilter>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLSamplerMinMagFilter {
     Nearest = 0,
@@ -16,7 +16,7 @@ pub enum MTLSamplerMinMagFilter {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlsamplermipfilter>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLSamplerMipFilter {
     NotMipmapped = 0,
@@ -25,7 +25,7 @@ pub enum MTLSamplerMipFilter {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlsampleraddressmode>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLSamplerAddressMode {
     ClampToEdge = 0,
@@ -37,7 +37,7 @@ pub enum MTLSamplerAddressMode {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlsamplerbordercolor>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLSamplerBorderColor {
     TransparentBlack = 0,

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -10,7 +10,7 @@ use super::*;
 use objc::runtime::{NO, YES};
 
 /// See <https://developer.apple.com/documentation/metal/mtltexturetype>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum MTLTextureType {
@@ -26,7 +26,7 @@ pub enum MTLTextureType {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtltexturecompressiontype>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum MTLTextureCompressionType {
     Lossless = 0,

--- a/src/vertexdescriptor.rs
+++ b/src/vertexdescriptor.rs
@@ -8,7 +8,7 @@
 use super::NSUInteger;
 
 /// See <https://developer.apple.com/documentation/metal/mtlvertexformat>
-#[repr(u64)]
+#[repr(usize)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLVertexFormat {
@@ -67,7 +67,7 @@ pub enum MTLVertexFormat {
 }
 
 /// See <https://developer.apple.com/documentation/metal/mtlvertexstepfunction>
-#[repr(u64)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MTLVertexStepFunction {
     Constant = 0,


### PR DESCRIPTION
All Metal framework enums use NS_ENUM(NSUInteger, ...) where NSUInteger is `unsigned long` — 8 bytes on LP64 (arm64) but 4 bytes on ILP32 (arm64_32, used by watchOS on Apple Watch Series 6–9 and SE2). Found this while making Multi-Draw Indirect in wgpu-native work on Apple Watch 6/SE2 (A13 CPU/GPU equivalent).

Using #[repr(u64)] forces all enums to 8 bytes regardless of platform, which corrupts the stack when passed via msg_send! on ILP32: the caller places 8 bytes where the ObjC runtime expects 4, misaligning every subsequent argument.

Fix: #[repr(u64)] -> #[repr(usize)], #[repr(i64)] -> #[repr(isize)]. This matches NSUInteger/NSInteger width on all Apple platforms.

Also fixes MTLDeviceLocation::Unspecified which used u64::MAX — this doesn't fit in a usize on ILP32. Changed to usize::MAX which correctly represents NSUIntegerMax on all platforms.

Zero behavioral change on 64-bit platforms (usize == u64).

Tested on:
- Apple Watch SE2 (arm64_32, S6/A13, watchOS 11.6)
- Apple Watch Series 10 (arm64, S9/A15, watchOS 26.4)