### PR TITLE
Fix: resolve_counter_range returns uninitialized memory

### DIFF
--- a/src/counters.rs
+++ b/src/counters.rs
@@ -71,7 +71,11 @@ impl CounterSampleBufferRef {
     pub fn resolve_counter_range(&self, range: crate::NSRange) -> Vec<NSUInteger> {
         let len = range.length as usize;
         let mut data: Vec<NSUInteger> = Vec::with_capacity(len); // allocated, but len remains 0
-        let total_bytes = (len * size_of::<NSUInteger>()) as u64;
+        let total_bytes: u64 = len
+            .checked_mul(size_of::<NSUInteger>())
+            .expect("overflow total_bytes")
+            .try_into()
+            .expect("total_bytes exceeds u64");
         unsafe {
             let ns_data: *mut crate::Object = msg_send![self, resolveCounterRange: range];
             let () = msg_send![ns_data, getBytes: data.as_mut_ptr() length: total_bytes];

--- a/src/counters.rs
+++ b/src/counters.rs
@@ -69,12 +69,13 @@ impl CounterSampleBufferRef {
     }
 
     pub fn resolve_counter_range(&self, range: crate::NSRange) -> Vec<NSUInteger> {
-        let mut data = Vec::with_capacity(range.length as usize);
-        let total_bytes = size_of_val(data.as_slice()) as u64;
+        let len = range.length as usize;
+        let mut data: Vec<NSUInteger> = Vec::with_capacity(len); // allocated, but len remains 0
+        let total_bytes = (len * size_of::<NSUInteger>()) as u64;
         unsafe {
             let ns_data: *mut crate::Object = msg_send![self, resolveCounterRange: range];
             let () = msg_send![ns_data, getBytes: data.as_mut_ptr() length: total_bytes];
-            data.set_len(range.length as usize);
+            data.set_len(len);
         }
         data
     }

--- a/src/counters.rs
+++ b/src/counters.rs
@@ -69,9 +69,9 @@ impl CounterSampleBufferRef {
     }
 
     pub fn resolve_counter_range(&self, range: crate::NSRange) -> Vec<NSUInteger> {
-        let len = range.length as usize;
-        let mut data: Vec<NSUInteger> = Vec::with_capacity(len); // allocated, but len remains 0
-        let total_bytes: u64 = len
+        let length = range.length as usize;
+        let mut data: Vec<NSUInteger> = Vec::with_capacity(length); // allocated, but len remains 0
+        let total_bytes: u64 = length
             .checked_mul(size_of::<NSUInteger>())
             .expect("overflow total_bytes")
             .try_into()
@@ -79,7 +79,7 @@ impl CounterSampleBufferRef {
         unsafe {
             let ns_data: *mut crate::Object = msg_send![self, resolveCounterRange: range];
             let () = msg_send![ns_data, getBytes: data.as_mut_ptr() length: total_bytes];
-            data.set_len(len);
+            data.set_len(length);
         }
         data
     }


### PR DESCRIPTION
The function `CounterSampleBufferRef::resolve_counter_range` returned uninitialized memory. Found this while doing some audits. I don't think it is exploitable.

## Issue

Commit https://github.com/gfx-rs/metal-rs/commit/17a07cb4e6b79f1169cf94664cea5c33c1d4cc2c changed the data creation from "initialized with 0x00" to "allocate capacity". That is a valid intent for performance optimisation since the code in the `unsafe` block will override the data later.

However, the computation of `total_bytes` uses the length of `data.as_slice()`. Since `.as_slice()` uses the actual `length`, the value `total_bytes` will always be `0`. As a result, `msg_send![ns_data, getBytes: data.as_mut_ptr() length: total_bytes];` will always copy `0` bytes.

The `.set_len` call will use the user-provided `range.length` and hence the returned `data` will be set to the expected length, but all bytes of the vector are uninitialized.

## Fix

Calculate `total_bytes` using the user-provided `range`.

Happy to remove the checks on multiplication and cast if deemed unnecessary. Can also return an empty vec on failure instead of panic.

Alternatively, reverting https://github.com/gfx-rs/metal-rs/commit/17a07cb4e6b79f1169cf94664cea5c33c1d4cc2c  is safe.